### PR TITLE
Documenting ability to control log level during micro_bosh installation

### DIFF
--- a/openstack/deploying_microbosh.html.md
+++ b/openstack/deploying_microbosh.html.md
@@ -312,6 +312,14 @@ If for some reason the deploy process gets stucked or fails, you can check the l
     I, [2013-06-14T13:07:36.171820 #13692] [0x366ff0]  INFO -- : Director is ready: {"name"=>"microbosh-openstack", "uuid"=>"fd581363-02cd-41c6-8bed-87780391cff7", "version"=>"1.5.0.pre.3 (release:bef17df0 bosh:bef17df0)", "user"=>nil, "cpi"=>"openstack", "features"=>{"dns"=>
     {"status"=>true, "extras"=>{"domain_name"=>"microbosh"}}, "compiled_package_cache"=>{"status"=>false, "extras"=>{"provider"=>nil}}}
 
+Note that you can control the logging debug level in the manifest:
+
+```
+logging:
+  # If needed increase the default logging level to trace REST traffic with IaaS providers
+  level: debug
+```
+
 ## <a id="test_microbosh"></a>Testing your Micro BOSH ##
 
 ### <a id="microbosh_target"></a>Set target ###

--- a/vcloud/micro_bosh-vcloud.yml
+++ b/vcloud/micro_bosh-vcloud.yml
@@ -40,3 +40,10 @@ cloud:
 apply_spec:
   properties:
       vcloud:
+
+logging:
+  # If needed increase the default logging level to trace REST traffic with IaaS providers. Default is info
+  level: info
+  # Default location is <deployment_dir>/bosh_micro_deploy.log
+  # file :
+

--- a/vsphere/deploying_micro_bosh.md
+++ b/vsphere/deploying_micro_bosh.md
@@ -125,6 +125,12 @@ apply_spec:
         # The BOSH powerDNS contacts the following DNS server for serving DNS entries from other domains.
         recursor: <ip_for_dns>
 
+logging:
+  # If needed increase the default logging level to trace REST traffic with IaaS providers. Default is info
+  level: info
+  # Default location is <deployment_dir>/bosh_micro_deploy.log
+  # file :
+
 
 ~~~
 


### PR DESCRIPTION
Useful when micro_bosh.deploy displays errors such as 

```
E, [2014-02-18T19:18:19.622573 #6243] [create_vm(bm-14fa2662-766c-4b4c-8901-52b6526bd7c0, urn:vcloud:catalogitem:c2f0ef9b-7a30-44dc-9c69-a96d26f38400, {"ram"=>8192, "disk"=>16384, "cpu"=>4}, ...)] ERROR -- : RestClient exception (retry after 200ms): 400 Bad Request
```
