### PR TITLE
Get rid of --pre flags on bosh cli installation.

### DIFF
--- a/vsphere/deploying_micro_bosh.md
+++ b/vsphere/deploying_micro_bosh.md
@@ -37,8 +37,8 @@ $ sudo apt-get -y install libsqlite3-dev genisoimage
 * Install the BOSH Deployer Ruby gem.
 
 <pre class="terminal">
-$ gem install bosh_cli --pre
-$ gem install bosh_cli_plugin_micro --pre
+$ gem install bosh_cli
+$ gem install bosh_cli_plugin_micro
 </pre>
 
 Once you have installed the deployer, you will be able to use `bosh micro`


### PR DESCRIPTION
Based on https://www.pivotaltracker.com/s/projects/956238/stories/61872478

You should no longer put --pre on a bosh cli installation command.
