### PR TITLE
Include the settings for nats ping timeouts

### DIFF
--- a/vsphere/deploying_micro_bosh.md
+++ b/vsphere/deploying_micro_bosh.md
@@ -106,6 +106,9 @@ cloud:
 
 apply_spec:
   properties:
+    nats:
+      ping_max_outstanding: 20
+      ping_interval: 20
     vcenter:
       host: <vcenter_ip>
       user: <vcenter_userid>


### PR DESCRIPTION
This microbosh manifest didn't include the settings for ping_max_outstanding and ping_interval, which users will probably need to change based on https://groups.google.com/a/cloudfoundry.org/forum/#!topic/bosh-users/mWo7A-HqJoo
