### PR TITLE
Set a default pair of NTP servers for convenience.

### DIFF
--- a/vsphere/deploying_micro_bosh.md
+++ b/vsphere/deploying_micro_bosh.md
@@ -86,8 +86,8 @@ cloud:
   properties:
     agent:
       ntp:
-        - <ntp_host_1>
-        - <ntp_host_2>
+        - 0.north-america.pool.ntp.org
+        - 1.north-america.pool.ntp.org
     vcenters:
       - host: <vcenter_ip>
         user: <vcenter_userid>


### PR DESCRIPTION
I refer you to https://github.com/cloudfoundry/docs-deploying-cf/blob/master/openstack/deploying_microbosh.html.md which has North American NTP servers as defaults.
