### PR TITLE
document that cf-173.yml doesn't work with these docs

### DIFF
--- a/vcloud/deploy_cf.md
+++ b/vcloud/deploy_cf.md
@@ -101,7 +101,7 @@ For this exercise, we'll use a release from the public repository. Clone this re
 <pre class="terminal">
 $ git clone https://github.com/cloudfoundry/cf-release.git
 $ cd cf-release
-$ bosh upload release releases/cf-xxx.yml # These docs have been tested with cf-147.yml
+$ bosh upload release releases/cf-xxx.yml # These docs have been tested with cf-147.yml ; they do NOT work with cf-173.yml
 </pre>
 
 You'll see a flurry of output as BOSH configures and uploads release components. Here's a shortened version:


### PR DESCRIPTION
I got tripped up trying to run through this tutorial on the latest
release.  Too much has changed:
- the release.tgz has doubled in size from 1.3G to 2.5G and won't fit,
  exploded, on the microBOSH instance's /var/vcap/data volume
- cf-173 doesn't define the health_manager_next template, required by
  the sample cf.yml.erb file
