### PR TITLE
Deployment instructions are for v170

### DIFF
--- a/common/cf-release.html.md
+++ b/common/cf-release.html.md
@@ -1,36 +1,36 @@
 ---
-title: Using the latest CF-Release
----
 
-## <a id='intro'></a> Introduction ##
+title: Using the latest CF-Release
+----------------------------------
+
+<a id='intro'></a> Introduction
+-------------------------------
 
 [CF-Release](https://github.com/cloudfoundry/cf-release) is the BOSH [release](/bosh/reference/index.html#bosh-release) repository for Cloud Foundry. Use this with a custom manifest for your environment to deploy Cloud Foundry.
 
 This short guide shows how to, after [bootstrapping BOSH](/deploying/), create a Cloud Foundry release ready to deploy to your environment.
 
-NOTE: These instructions are for v145 release of Cloud Foundry. We strongly recommend using the [highest final version tag of cf-release](https://github.com/cloudfoundry/cf-release/releases).
+NOTE: These instructions are for v170 release of Cloud Foundry. We strongly recommend using the [highest final version tag of cf-release](https://github.com/cloudfoundry/cf-release/releases). Though modifications may be required to the deployment manifest later on.
 
-<pre class="terminal">
-$ bosh upload release releases/cf-145.yml
-</pre>
-
-## <a id='clone'></a> Clone CF-Release ##
+<a id='clone'></a> Clone CF-Release
+-----------------------------------
 
 Create / find a folder to keep your clone of the CF-Release repository and clone it from Github;
 
 <pre class="terminal">
 mkdir -p ~/bosh-workspace/releases
 cd ~/bosh-workspace/releases
-git clone -b release-candidate git://github.com/cloudfoundry/cf-release.git
+git clone https://github.com/cloudfoundry/cf-release.git
 cd cf-release
 </pre>
 
-## <a id='upload-the-release'></a> Upload the release ##
+<a id='upload-the-release'></a> Upload the release
+--------------------------------------------------
 
-Releases of Cloud Foundry are published regularly (approximately weekly) and you upload them to your bosh using `bosh upload release` where the cf-145.yml file should be substituted with the cf-release version, which we recommend to be the [highest final version tag of cf-release](https://github.com/cloudfoundry/cf-release/releases):
+Releases of Cloud Foundry are published regularly (approximately weekly) and you upload them to your bosh using `bosh upload release` where the cf-170.yml file should be substituted with the cf-release version, which we recommend to be the [highest final version tag of cf-release](https://github.com/cloudfoundry/cf-release/releases):
 
 <pre class="terminal">
-$ bosh upload release releases/cf-145.yml
+$ bosh upload release releases/cf-170.yml
 
 Copying packages
 ----------------
@@ -56,7 +56,7 @@ $ bosh releases
 +------+----------+-------------+
 | Name | Versions | Commit Hash |
 +------+----------+-------------+
-| cf   | 145      | 121623ca    |
+| cf   | 170      | 121623ca    |
 +------+----------+-------------+
 </pre>
 


### PR DESCRIPTION
Yes, there are newer CF releases; but this is at least to make all Openstack install
instructions consistent.
