### PR TITLE
Updated the "signing_key" and "verification_key" examples to include the...

### DIFF
--- a/ec2/bootstrap-aws-vpc.html.md.erb
+++ b/ec2/bootstrap-aws-vpc.html.md.erb
@@ -274,8 +274,10 @@ properties:
     admin:
       client_secret: PLACEHOLDER-UAA-ADMIN-CLIENT-SECRET
     jwt:
-      signing_key: PLACEHOLDER-UAA-JWT-SIGNING-KEY
-      verification_key: PLACEHOLDER-UAA-JWT-VERIFICATION-KEY
+      signing_key: |
+      PLACEHOLDER-UAA-JWT-SIGNING-KEY
+      verification_key: |
+      PLACEHOLDER-UAA-JWT-VERIFICATION-KEY
     clients:
       login:
         secret: PLACEHOLDER-UAA-CLIENTS-LOGIN-SECRET


### PR DESCRIPTION
Updated the "signing_key" and "verification_key" examples to include the yaml "|" character used to support multiline data as an RSA key set often is.  We ran into a minor issue where this bit of information would have been helpful.
