### PR TITLE
Fixed reversed VPC AZ ordering

### DIFF
--- a/ec2/bootstrap-aws-vpc.html.md.erb
+++ b/ec2/bootstrap-aws-vpc.html.md.erb
@@ -68,8 +68,8 @@ replacing the values in each line to match your configuration:
     export BOSH_AWS_ACCESS_KEY_ID=AWS_ACCESS_KEY_ID
     export BOSH_AWS_SECRET_ACCESS_KEY=AWS_SECRET_ACCESS_KEY
     export BOSH_AWS_REGION=my-aws-region
+    export BOSH_VPC_PRIMARY_AZ=us-east-1d   # see note below    
     export BOSH_VPC_SECONDARY_AZ=us-east-1a # see note below
-    export BOSH_VPC_PRIMARY_AZ=us-east-1d   # see note below
     ~~~
 
     <p class="note"><strong>Note</strong>: The values you add for <code>BOSH_VPC_DOMAIN</code> and <code>BOSH_VPC_SUBDOMAIN</code> must correspond to the DNS domain name you set up when configuring Route 53.</p>


### PR DESCRIPTION
The BOSH_VPC_SECONDARY_AZ export should be after the primary for readability.
