### PR TITLE
Openstack typo

### DIFF
--- a/cf-manifest-spiff.html.md.erb
+++ b/cf-manifest-spiff.html.md.erb
@@ -101,7 +101,7 @@ environment.
     * For instructions specific to AWS, see [Customizing the Cloud Foundry Deployment Manifest Stub for AWS](./cf-stub-aws.html).
     * For instructions specific to vSphere, see [Customizing the Cloud Foundry Deployment Manifest Stub for vSphere](./cf-stub-vsphere.html).
     * For instructions specific to vCloud, see [Customizing the Cloud Foundry Deployment Manifest Stub for vCloud](./cf-stub-vcloud.html).
-    * For instructions specific to vSphere, see [Customizing the Cloud Foundry Deployment Manifest Stub for OpenStack](./cf-stub-openstack.html).
+    * For instructions specific to Openstack, see [Customizing the Cloud Foundry Deployment Manifest Stub for OpenStack](./cf-stub-openstack.html).
 
 ##<a id="generate-manifest"></a>Step 4: Generate a Deployment Manifest ##
 


### PR DESCRIPTION
Just typo Fix . Vsphere was there instead of Openstack.