### PR TITLE
Revert "fix typo in cf-manifest-spiff.html.md.erb"

### DIFF
--- a/cf-manifest-spiff.html.md.erb
+++ b/cf-manifest-spiff.html.md.erb
@@ -84,7 +84,7 @@ Customize a deployment manifest stub with information specific to your
 environment.
 To do this:
 
-1. Browse to the `cf-release/spec/fixtures` directory.
+1. Browse to the `cf-releases/spec/fixtures` directory.
 This directory contains folders for the following environments:
     * AWS
     * OpenStack


### PR DESCRIPTION
Reverts cloudfoundry/docs-deploying-cf#48