### PR TITLE
Remove fog  version constraint notice

### DIFF
--- a/openstack/using_swift_blobstore.html.md
+++ b/openstack/using_swift_blobstore.html.md
@@ -13,8 +13,6 @@ Controller's blobstore, the Cloud Controller generates temporary URLs pointing
 to the required files and provides them to the DEA.
 The DEA can use the URLs to download the files, execute staging tasks, then deliver back the results. To help ensure data security, the generated URLs are valid for a limited amount of time.
 
-<p class='note'><strong>Note</strong>: This feature depends on the Cloud Controller using the <strong>fog</strong> gem version 1.16.0 or higher.</p>
-
 ## OpenStack Prerequisites ##
 
 To use the temporary URL feature, the OpenStack user needs the **ResellerAdmin** role.


### PR DESCRIPTION
Fog is at version >= 1.16.0 in the CC for a long time already.
This suggests that users still have to wait for something to happen
to be able to use Swift, which is not the case.