### PR TITLE
Instructions for preparing ruby to run the installation script

### DIFF
--- a/boshlite/create_a_manifest.html.md.erb
+++ b/boshlite/create_a_manifest.html.md.erb
@@ -38,6 +38,8 @@ $ git clone https://github.com/cloudfoundry/cf-release.git
 
 ##<a id="generate-manifest"></a>Generate the Manifest ##
 
+1. Ensure that ruby-2.1.8 is installed with [rbenv](https://github.com/rbenv/rbenv#installation).  `rbenv install 2.1.8`
+1. Ensure that bundler is installed.  `gem install bundler`
 1. Install [spiff](https://github.com/cloudfoundry-incubator/spiff).
 
 1. Use the `scripts/generate-bosh-lite-dev-manifest` command to create a


### PR DESCRIPTION
Updated to the installation instructions for the following reasons:

Running the script without ruby-2.1.8 gave the following error (I had ruby 2.2.0): 

```
rbenv: version `2.1.8' is not installed (set by /Users/pivotal/workspace/av/bosh-demo/cf-release/.ruby-version)
rbenv: version `2.1.8' is not installed (set by /Users/pivotal/workspace/av/bosh-demo/cf-release/.ruby-version)
Can only target Bosh Lite Director. Please use 'bosh target' before running this script.
rbenv: version `2.1.8' is not installed (set by /Users/pivotal/workspace/av/bosh-demo/cf-release/.ruby-version)
```

After installing ruby-2.1.8, the script gave the following error until I installed the bundler gem:

```
/Users/pivotal/.rbenv/versions/2.1.8/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- bundler/setup (LoadError)
	from /Users/pivotal/.rbenv/versions/2.1.8/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/Users/pivotal/.rbenv/versions/2.1.8/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- bundler/setup (LoadError)
	from /Users/pivotal/.rbenv/versions/2.1.8/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
Can only target Bosh Lite Director. Please use 'bosh target' before running this script.
```