### PR TITLE
Revert "Typo broke hyperlink. Fixed."

### DIFF
--- a/vcloud/index.html.md.erb
+++ b/vcloud/index.html.md.erb
@@ -10,7 +10,7 @@ title: Deploying Cloud Foundry on vCloud Air or vCloud Director
 
 ## Deploy BOSH ##
 
-* Initialize [BOSH on vCloud](http://bosh.io/docs/init-vcloud.html).
+* Initialize [BOSH on vCloud](https://http://bosh.io/docs/init-vcloud.html).
 
 ## Deploy Cloud Foundry ##
 


### PR DESCRIPTION
Reverts cloudfoundry/docs-deploying-cf#78