### PR TITLE
Revert "Update documentation for uaa ssl properties"

### DIFF
--- a/aws/cf-stub.html.md.erb
+++ b/aws/cf-stub.html.md.erb
@@ -254,16 +254,6 @@ properties:
   </tr>
   <tr>
     <td><pre><code>
-    sslCertificate: UAA_SSL_CERTIFICATE
-    sslPrivateKey: UAA_SSL_PRIVATE_KEY
-    </code></pre></td>
-    <td>Replace <code>UAA_SSL_PRIVATE_KEY</code> with a PEM-encoded RSA private key, and <code>UAA_SSL_CERTIFICATE</code> with the corresponding SSL certificate<br/>
-    Paste in the full keys, including the "BEGIN" and "END" delimiter lines.<br/>
-    In order to turn ssl off, set <code>uaa.ssl.port</code> to -1 and leave these two properties blank. 
-    </td>
-  </tr>
-  <tr>
-    <td><pre><code>
     scim:
       users:
         - admin|ADMIN_PASSWORD|scim.write,scim.read,o...

--- a/common/vsphere-vcloud-cf-stub.html.md.erb
+++ b/common/vsphere-vcloud-cf-stub.html.md.erb
@@ -190,16 +190,6 @@ properties:
   </tr>
   <tr>
     <td><pre><code>
-    sslCertificate: UAA_SSL_CERTIFICATE
-    sslPrivateKey: UAA_SSL_PRIVATE_KEY
-    </code></pre></td>
-    <td>Replace <code>UAA_SSL_PRIVATE_KEY</code> with a PEM-encoded RSA private key, and <code>UAA_SSL_CERTIFICATE</code> with the corresponding SSL certificate<br/>
-    Paste in the full keys, including the "BEGIN" and "END" delimiter lines.<br/>
-    In order to turn ssl off, set <code>uaa.ssl.port</code> to -1 and leave these two properties blank. 
-    </td>
-  </tr>
-  <tr>
-    <td><pre><code>
     scim:
       users:
         - admin|ADMIN_PASSWORD|scim.write,scim.read,o...

--- a/openstack/cf-stub.html.md.erb
+++ b/openstack/cf-stub.html.md.erb
@@ -197,16 +197,6 @@ properties:
   </tr>
   <tr>
     <td><pre><code>
-    sslCertificate: UAA_SSL_CERTIFICATE
-    sslPrivateKey: UAA_SSL_PRIVATE_KEY
-    </code></pre></td>
-    <td>Replace <code>UAA_SSL_PRIVATE_KEY</code> with a PEM-encoded RSA private key, and <code>UAA_SSL_CERTIFICATE</code> with the corresponding SSL certificate<br/>
-    Paste in the full keys, including the "BEGIN" and "END" delimiter lines.<br/>
-    In order to turn ssl off, set <code>uaa.ssl.port</code> to -1 and leave these two properties blank. 
-    </td>
-  </tr>
-  <tr>
-    <td><pre><code>
     scim:
       users:
         - admin|ADMIN_PASSWORD|scim.write,scim.read,o...


### PR DESCRIPTION
This reverts commit 98920e00100ab1192ac39f71e81a03628494e5db. The default behavior has changed to not require these properties.

[#114585365] https://www.pivotaltracker.com/story/show/114585365

Signed-off-by: Jonathan Lo <jlo@us.ibm.com>