### PR TITLE
Should change the private key file name to bosh.pem

### DIFF
--- a/aws/setup_bosh_aws.html.md.erb
+++ b/aws/setup_bosh_aws.html.md.erb
@@ -8,10 +8,10 @@ In the [previous step](./setup_aws.html) you prepared an AWS environment for BOS
 ## <a id="copy-keypair"></a>Copy the RSA Private Key
 When `bosh aws create` prepared your AWS environment, it generated an RSA private key file and saved it into your `~/.ssh` directory. To deploy BOSH, you need this file in your deployment directory.
 
-Copy the RSA private key file, `id_rsa_bosh`, to the `cf-example` directory you created in the [previous step](./setup_aws.html).
+Copy the RSA private key file, `id_rsa_bosh`, to the `cf-example` directory you created in the [previous step](./setup_aws.html) and rename it as `bosh.pem`.
 
 <pre class='terminal'>
-$ cp ~/.ssh/id_rsa_bosh ~/deployments/cf-example
+$ cp ~/.ssh/id_rsa_bosh ~/deployments/cf-example/bosh.pem
 </pre>
 
 ## <a id="create-manifest"></a>Create a Deployment Manifest


### PR DESCRIPTION
Document should indicate that the user have to rename the private key file to the name expected by bosh-init