### PR TITLE
Move scripts/update section before generate-manifest.

### DIFF
--- a/boshlite/create_a_manifest.html.md.erb
+++ b/boshlite/create_a_manifest.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Create a Deployment Manifest for Cloud Foundry on BOSH-Lite
-owner: owner: Runtime
+owner: Runtime
 ---
 
 <strong><%= modified_date %></strong>
@@ -38,6 +38,17 @@ $ git clone https://github.com/cloudfoundry/cf-release.git
 </pre>
 
 ##<a id="generate-manifest"></a>Generate the Manifest ##
+
+Ensure that you have the most up-to-date version of the Cloud Foundry code and all required submodules.
+
+1. From the `cf-release` directory that you cloned when you created the
+manifest, run the update script to fetch all the submodules.
+
+    <pre class="terminal">
+    $ cd cf-release
+    $ ./scripts/update
+    </pre>
+
 1. Install the Ruby version listed in the `cf-release/ruby_version` file of the cf-release repository. You can manage your Ruby versions using `rvm`, `rbenv`, or `chruby`.
 1. Run `gem install bundler` to install `bundler`.
 1. Install [spiff](https://github.com/cloudfoundry-incubator/spiff).

--- a/common/create_a_manifest.html.md.erb
+++ b/common/create_a_manifest.html.md.erb
@@ -58,6 +58,16 @@ $ git clone https://github.com/cloudfoundry/cf-release.git
 
 ##<a id="generate-manifest"></a>Generate the Manifest ##
 
+Ensure that you have the most up-to-date version of the Cloud Foundry code and all required submodules.
+
+1. From the `cf-release` directory that you cloned when you created the
+manifest, run the update script to fetch all the submodules.
+
+    <pre class="terminal">
+    $ cd cf-release
+    $ ./scripts/update
+    </pre>
+
 1. Install [spiff](https://github.com/cloudfoundry-incubator/spiff).
 
 1. The following command, run from the `cf-release` directory, creates a deployment manifest named `cf-deployment.yml`.

--- a/common/deploy.html.md.erb
+++ b/common/deploy.html.md.erb
@@ -26,16 +26,6 @@ bosh upload stemcell ~/downloads/light-bosh-stemcell-3202-aws-xen-hvm-ubuntu-tru
 
 ##<a id="create-release"></a>Build the Cloud Foundry Release##
 
-Ensure that you have the most up-to-date version of the Cloud Foundry code and all required submodules. Then run `bosh create release` to prepare the full release on your machine before deploying it to your environment.
-
-1. From the `cf-release` directory that you cloned when you created the
-manifest, run the update script to fetch all the submodules.
-
-    <pre class="terminal">
-    $ cd cf-release
-    $ ./scripts/update
-    </pre>
-
 1. Use `bosh create release` to create a Cloud Foundry release.
 After some processing, this command prompts you for a development release name. The release names correspond to the files in `cf-release/releases`.
 


### PR DESCRIPTION
- otherwise the update script will clobber the newly-created manifest.

This resolves https://github.com/cloudfoundry/cf-release/issues/929

[#115492433]

Signed-off-by: Nima Kaviani <nkavian@us.ibm.com>