### PR TITLE
Permission update for tags

### DIFF
--- a/vsphere/vcenter_user_privileges.html.md.erb
+++ b/vsphere/vcenter_user_privileges.html.md.erb
@@ -21,6 +21,8 @@ owner: Runtime
 | Global                                      |                                          |
 |                                             | cancel task                              |
 |                                             | diagnostics                              |
+|                                             | manage custom attributes                 |
+|                                             | add custom attributes                    |
 | Host / Configuration (All)                  |                                          |
 |                                             | advanced setting                         |
 |                                             | authentication store                     |


### PR DESCRIPTION
vCenter will not get BOSH job/deployment/director attributes unless these permissions are set.