### PR TITLE
Document hm9000 certs for cf-stubs

### DIFF
--- a/aws/cf-stub.html.md.erb
+++ b/aws/cf-stub.html.md.erb
@@ -263,4 +263,17 @@ properties:
       If you deployed your database without <code>bosh aws create</code>, such as using the <code>postgres</code> job in cf-release, the <code>CCDB_*</code> values must match the configuration of the database node.
 	  </td>
   </tr>
+  <tr>
+    <td><pre><code>
+  hm9000:
+    ca_cert: HM9000_CA_CERT
+    server_cert: HM9000_SERVER_CERT
+    server_key: HM9000_SERVER_KEY
+    agent_cert: HM9000_AGENT_CERT
+    agent_key: HM9000_AGENT_KEY
+    </code></pre></td>
+    <td>
+      Generate ssl certs for hm9000 and replace these values. A script in the cf-release repository, <code>scripts/generate-hm9000-certs</code> can be used to generate self signed certs.
+    </td>
+  </tr>
 </table>

--- a/common/vsphere-vcloud-cf-stub.html.md.erb
+++ b/common/vsphere-vcloud-cf-stub.html.md.erb
@@ -220,6 +220,19 @@ properties:
   </tr>
   <tr>
     <td><pre><code>
+  hm9000:
+    ca_cert: HM9000_CA_CERT
+    server_cert: HM9000_SERVER_CERT
+    server_key: HM9000_SERVER_KEY
+    agent_cert: HM9000_AGENT_CERT
+    agent_key: HM9000_AGENT_KEY
+    </code></pre></td>
+    <td>
+      Generate ssl certs for hm9000 and replace these values. A script in the cf-release repository, <code>scripts/generate-hm9000-certs</code> can be used to generate self signed certs.
+    </td>
+  </tr>
+  <tr>
+    <td><pre><code>
 jobs:
 - name: ha_proxy_z1
   properties:

--- a/openstack/cf-stub.html.md.erb
+++ b/openstack/cf-stub.html.md.erb
@@ -225,6 +225,19 @@ properties:
   </tr>
   <tr>
     <td><pre><code>
+  hm9000:
+    ca_cert: HM9000_CA_CERT
+    server_cert: HM9000_SERVER_CERT
+    server_key: HM9000_SERVER_KEY
+    agent_cert: HM9000_AGENT_CERT
+    agent_key: HM9000_AGENT_KEY
+    </code></pre></td>
+    <td>
+      Generate ssl certs for hm9000 and replace these values. A script in the cf-release repository, <code>scripts/generate-hm9000-certs</code> can be used to generate self signed certs.
+    </td>
+  </tr>
+  <tr>
+    <td><pre><code>
 jobs:
   - name: ha_proxy_z1
     networks:


### PR DESCRIPTION
With recent changes to HM9000, we would like to add some documentation on generating the proper certs.

Note: The manifest pulled in at the top of the files are from `cf-release master` which does not show the required stub changes. They should appear when the next version of CF is cut. 

[#118427247]

Signed-off-by: Swetha Repakula <srepaku@us.ibm.com>