### PR TITLE
Add blobstore configuration docs

### DIFF
--- a/aws/cf-stub.html.md.erb
+++ b/aws/cf-stub.html.md.erb
@@ -121,52 +121,160 @@ properties:
     staging_upload_password: STAGING_UPLOAD_PASSWORD
     bulk_api_password: BULK_API_PASSWORD
     db_encryption_key: CCDB_ENCRYPTION_KEY
-    </code></pre>
-
-    <code></pre>
-    BLOBSTORE:
-      blobstore_type: fog
-      fog_connection:
-        aws_access_key_id: AWS_ACCESS_KEY
-        aws_secret_access_key: AWS_SECRET_ACCESS_KEY
-        provider: AWS
-        region: us-east-1
-    BLOBSTORE:
-      blobstore_type: fog
-      fog_connection:
-        provider: AWS
-        region: us-east-1
-        use_iam_profile: true
-    </code></pre></td>
-
-    <code></pre>
-    BLOBSTORE:
-      blobstore_type: webdav
-      webdav_config:
-        public_endpoint: WEBDAV_PUBLIC_ENDPOINT
-        private_endpoint: WEBDAV_PRIVATE_ENDPOINT
-        username: WEBDAV_BASIC_AUTH_USER
-        password: WEBDAV_BASIC_AUTH_PASSWORD
-        ca_cert: WEBDAV_CERT
     </code></pre></td>
     <td>
-    The Cloud Controller API endpoint requires basic authentication. Replace <code>STAGING_UPLOAD_USER</code> and <code>STAGING_UPLOAD_PASSWORD</code> with a username and password of your choosing.
-    <br /><br />
-    Replace <code>BULK_API_PASSWORD</code> with a password of your choosing. Health Manager uses this password to access the Cloud Controller bulk API.
-    <br /><br />
-    Replace <code>CCDB_ENCRYPTION_KEY</code>
-    with a secure key that you generate to encrypt sensitive values in the Cloud Controller database.
-    <br /><br />
-    Cloud Controller uses four blobstores, <code>buildpacks</code>, <code>droplets</code>, <code>packages</code>, and <code>resource_pool</code>. These blobstores can be configured with
-    <code>blobstore_type</code> equal to either "fog" or "webdav". If not explicitly configured, "fog" will be used as the default.
-    <br /><br />
-    When using "fog" for a particular blobstore, you may configure a <code>fog_connection</code> hash, which will be passed through to the fog gem as-is. This can
-    be used to configure fog to use <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/introduction.html">AWS IAM Profiles</a>. Note, your BOSH director must
-    be <a href="https://bosh.io/docs/aws-iam-instance-profiles.html">configured to use IAM instance profiles</a>.
-    <br /><br />
-    When using "webdav" for a particular blobstore, it can be configured with a <code>webdav_config</code> hash. Replace <code>WEBDAV_PUBLIC_ENDPOINT</code> with the public URL
-    that resolves to your WebDAV installation. Replace <code>WEBDAV_PRIVATE_ENDPOINT</code> with a URL routable on your internal network. This will default to "https://blobstore.service.cf.internal"
-    if not set. Replace <code>WEBDAV_BASIC_AUTH_USER</code> and <code>WEBDAV_BASIC_AUTH_PASSWORD</code> with Basic AUTH credentials that Cloud Controller can use to talk your WebDAV installation.
+      The Cloud Controller API endpoint requires basic authentication. Replace <code>STAGING_UPLOAD_USER</code> and <code>STAGING_UPLOAD_PASSWORD</code> with a username and password of your choosing.
+      <br /><br />
+      Replace <code>BULK_API_PASSWORD</code> with a password of your choosing. Health Manager uses this password to access the Cloud Controller bulk API.
+      <br /><br />
+      Replace <code>CCDB_ENCRYPTION_KEY</code>
+      with a secure key that you generate to encrypt sensitive values in the Cloud Controller database.
+      <br /><br />
+    </td>
+  </tr>
+  <tr>
+    <td colspan=2>
+      Cloud Controller uses four blobstores, <code>buildpacks</code>, <code>droplets</code>, <code>packages</code>, and <code>resource_pool</code>. Each blobstore can be configured with <code>blobstore_type</code> equal to either "fog" or "webdav". If not explicitly configured, "fog" will be used as the default. When using "fog" for a particular blobstore, you may configure a <code>fog_connection</code> hash, which will be passed through to the fog gem as-is.
+    </td>
+  </tr>
+  <tr>
+    <td><pre><code>
+cc:
+  buildpacks:
+    blobstore_type: fog
+    buildpack_directory_key: some-aws-blobstore-bucket
+    fog_connection: &fog_connection
+      aws_access_key_id: AWS_ACCESS_KEY
+      aws_secret_access_key: AWS_SECRET_ACCESS_KEY
+      provider: AWS
+      region: us-east-1
+  droplets:
+    blobstore_type: fog
+    droplet_directory_key: some-aws-droplet-bucket
+    fog_connection: \*fog_connection
+  packages:
+    blobstore_type: fog
+    app_package_directory_key: some-aws-package-bucket
+    fog_connection: \*fog_connection
+  resource_pool:
+    blobstore_type: fog
+    droplet_directory_key: some-aws-resource-bucket
+    fog_connection: \*fog_connection
+    </code></pre></td>
+    <td>
+      Fog can be configured to use an `AWS_ACCESS_KEY` and `AWS_SECRET_ACCESS_KEY`. These credentials should be assigned an IAM policy that allows all S3 actions on each of the buckets in the example.
+    </td>
+  </tr>
+
+  <tr>
+    <td><pre><code>
+cc:
+  buildpacks:
+    blobstore_type: fog
+    buildpack_directory_key: some-aws-blobstore-bucket
+    fog_connection: &fog_connection
+      provider: AWS
+      region: us-east-1
+      use_iam_profile: true
+  droplets:
+    blobstore_type: fog
+    droplet_directory_key: some-aws-droplet-bucket
+    fog_connection: \*fog_connection
+  packages:
+    blobstore_type: fog
+    app_package_directory_key: some-aws-package-bucket
+    fog_connection: \*fog_connection
+  resource_pool:
+    blobstore_type: fog
+    droplet_directory_key: some-aws-resource-bucket
+    fog_connection: \*fog_connection
+    </code></pre></td>
+    <td>
+       Fog can be configured to use <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html">AWS IAM Instance Profiles</a>.
+       <br/><br/>
+       1. Follow the <a href="http://bosh.io/docs/aws-iam-instance-profiles.html#director-with-s3-blobstore">AWS CPI and Director configured with an S3 blobstore instructions</a>
+       <br/><br/>
+       2. Configure an additional `cloud-controller` IAM role that gives access to both the BOSH S3 buckets and the Cloud Controller S3 buckets:
+          <pre><code>
+{
+"Version": "2012-10-17",
+"Statement": [{
+  "Effect": "Allow",
+  "Action": [ "s3:\*" ],
+  "Resource": [
+    "arn:aws:s3:::&lt;bosh_bucket_name&gt;",
+    "arn:aws:s3:::&lt;bosh_bucket_name&gt;/\*",
+    "arn:aws:s3:::&lt;some-aws-blobstore-bucket&gt;",
+    "arn:aws:s3:::&lt;some-aws-blobstore-bucket&gt;/\*",
+    "arn:aws:s3:::&lt;some-aws-droplet-bucket&gt;",
+    "arn:aws:s3:::&lt;some-aws-droplet-bucket&gt;/\*",
+    "arn:aws:s3:::&lt;some-aws-package-bucket&gt;",
+    "arn:aws:s3:::&lt;some-aws-package-bucket&gt;/\*",
+    "arn:aws:s3:::&lt;some-aws-resource-bucket&gt;",
+    "arn:aws:s3:::&lt;some-aws-resource-bucket&gt;/\*",
+  ]
+}]
+}
+          </pre></code>
+       3. In your Cloud Foundry deployment manifest, configure a resource pool to use the `cloud-controller` IAM role:
+         <pre><code>
+resource_pools:
+- name: cloud-controller-resource-pool
+  network: default
+  stemcell: { ... }
+  cloud_properties:
+    instance_type: c3.large
+    iam_instance_profile: cloud-controller
+         </pre></code>
+       4. Assign all Cloud Controller jobs (api_z\*) and Cloud Controller Worker jobs (api_worker_z\*) to the `cloud-controller-resource-pool`
+    </td>
+  </tr>
+
+  <tr>
+    <td><pre><code>
+blobstore:
+  admin_users:
+  - password: WEBDAV_BASIC_AUTH_PASSWORD
+    username: WEBDAV_BASIC_AUTH_USER
+  port: 80
+  secure_link:
+    secret: WEBDAV_SECRET
+  tls:
+    cert: WEBDAV_CERT
+    port: 443
+    private_key: WEBDAV_PRIVATE_KEY
+    ca_cert: WEBDAV_CA_CERT_BUNDLE
+cc:
+  buildpacks:
+    blobstore_type: webdav
+    buildpack_directory_key: cc-buildpacks
+    webdav_config: &webdav_config
+      public_endpoint: WEBDAV_PUBLIC_ENDPOINT
+      private_endpoint: WEBDAV_PRIVATE_ENDPOINT
+      username: WEBDAV_BASIC_AUTH_USER
+      password: WEBDAV_BASIC_AUTH_PASSWORD
+      ca_cert: WEBDAV_CA_CERT_BUNDLE
+  droplets:
+    blobstore_type: webdav
+    droplet_directory_key: cc-droplets
+    webdav_config: \*webdav_config
+  packages:
+    blobstore_type: webdav
+    app_package_directory_key: cc-packages
+    webdav_config: \*webdav_config
+  resource_pool:
+    blobstore_type: webdav
+    droplet_directory_key: cc-resources
+    webdav_config: \*webdav_config
+    </code></pre></td>
+    <td>
+      When using "webdav" for a particular blobstore, it can be configured with a <code>webdav_config</code> hash.
+      Replace <code>WEBDAV_BASIC_AUTH_USER</code> and <code>WEBDAV_BASIC_AUTH_PASSWORD</code> with Basic AUTH credentials that Cloud Controller can use to talk your WebDAV installation.
+      Replace <code>WEBDAV_SECRET</code> with a secret phrase used to sign URLs.
+      Replace <code>WEBDAV_CERT</code>, <code>WEBDAV_PRIVATE_KEY</code>, and <code>WEBDAV_CA_CERT_BUNDLE</code> with proper TLS configuration that will be used for the internal blobstore.
+      Replace <code>WEBDAV_PUBLIC_ENDPOINT</code> with the public URL (e.g. https://blobstore.SYSTEM_DOMAIN) that resolves to your WebDAV installation.
+      Replace <code>WEBDAV_PRIVATE_ENDPOINT</code> with a URL routable on your internal network. This will default to "https://blobstore.service.cf.internal" if not set.
+      Replace <code>WEBDAV_BASIC_AUTH_USER</code> and <code>WEBDAV_BASIC_AUTH_PASSWORD</code> with Basic AUTH credentials that Cloud Controller can use to talk your WebDAV installation.
     </td>
   </tr>
   <tr>

--- a/aws/cf-stub.html.md.erb
+++ b/aws/cf-stub.html.md.erb
@@ -121,15 +121,51 @@ properties:
     staging_upload_password: STAGING_UPLOAD_PASSWORD
     bulk_api_password: BULK_API_PASSWORD
     db_encryption_key: CCDB_ENCRYPTION_KEY
-	  </code></pre></td>
+    </code></pre>
+
+    <code></pre>
+    BLOBSTORE:
+      blobstore_type: fog
+      fog_connection:
+        aws_access_key_id: AWS_ACCESS_KEY
+        aws_secret_access_key: AWS_SECRET_ACCESS_KEY
+        provider: AWS
+        region: us-east-1
+    BLOBSTORE:
+      blobstore_type: fog
+      fog_connection:
+        provider: AWS
+        region: us-east-1
+        use_iam_profile: true
+    </code></pre></td>
+
+    <code></pre>
+    BLOBSTORE:
+      blobstore_type: webdav
+      webdav_config:
+        public_endpoint: WEBDAV_PUBLIC_ENDPOINT
+        private_endpoint: WEBDAV_PRIVATE_ENDPOINT
+        username: WEBDAV_BASIC_AUTH_USER
+        password: WEBDAV_BASIC_AUTH_PASSWORD
+        ca_cert: WEBDAV_CERT
+    </code></pre></td>
     <td>
     The Cloud Controller API endpoint requires basic authentication. Replace <code>STAGING_UPLOAD_USER</code> and <code>STAGING_UPLOAD_PASSWORD</code> with a username and password of your choosing.
     <br /><br />
     Replace <code>BULK_API_PASSWORD</code> with a password of your choosing. Health Manager uses this password to access the Cloud Controller bulk API.
     <br /><br />
     Replace <code>CCDB_ENCRYPTION_KEY</code>
-    with a secure key that you generate to encrypt sensitive values in the
-    Cloud Controller database.
+    with a secure key that you generate to encrypt sensitive values in the Cloud Controller database.
+    <br /><br />
+    Cloud Controller uses four blobstores, <code>buildpacks</code>, <code>droplets</code>, <code>packages</code>, and <code>resource_pool</code>. These blobstores can be configured with
+    <code>blobstore_type</code> equal to either "fog" or "webdav". If not explicitly configured, "fog" will be used as the default.
+    <br /><br />
+    When using "fog" for a particular blobstore, you may configure a <code>fog_connection</code> hash, which will be passed through to the fog gem as-is. This can
+    be used to configure fog to use <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/introduction.html">AWS IAM Profiles</a>.
+    <br /><br />
+    When using "webdav" for a particular blobstore, it can be configured with a <code>webdav_config</code> hash. Replace <code>WEBDAV_PUBLIC_ENDPOINT</code> with the public URL
+    that resolves to your WebDAV installation. Replace <code>WEBDAV_PRIVATE_ENDPOINT</code> with a URL routable on your internal network. This will default to "https://blobstore.service.cf.internal"
+    if not set. Replace <code>WEBDAV_BASIC_AUTH_USER</code> and <code>WEBDAV_BASIC_AUTH_PASSWORD</code> with Basic AUTH credentials that Cloud Controller can use to talk your WebDAV installation.
     </td>
   </tr>
   <tr>

--- a/aws/cf-stub.html.md.erb
+++ b/aws/cf-stub.html.md.erb
@@ -161,7 +161,8 @@ properties:
     <code>blobstore_type</code> equal to either "fog" or "webdav". If not explicitly configured, "fog" will be used as the default.
     <br /><br />
     When using "fog" for a particular blobstore, you may configure a <code>fog_connection</code> hash, which will be passed through to the fog gem as-is. This can
-    be used to configure fog to use <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/introduction.html">AWS IAM Profiles</a>.
+    be used to configure fog to use <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/introduction.html">AWS IAM Profiles</a>. Note, your BOSH director must
+    be <a href="https://bosh.io/docs/aws-iam-instance-profiles.html">configured to use IAM instance profiles</a>.
     <br /><br />
     When using "webdav" for a particular blobstore, it can be configured with a <code>webdav_config</code> hash. Replace <code>WEBDAV_PUBLIC_ENDPOINT</code> with the public URL
     that resolves to your WebDAV installation. Replace <code>WEBDAV_PRIVATE_ENDPOINT</code> with a URL routable on your internal network. This will default to "https://blobstore.service.cf.internal"


### PR DESCRIPTION
This is a small improvement over #99 to include a link to the documentation for setting up BOSH IAM instance profiles.