### PR TITLE
Add vCenter-level privilege introduced in 2015

### DIFF
--- a/vsphere/vcenter_user_privileges.html.md.erb
+++ b/vsphere/vcenter_user_privileges.html.md.erb
@@ -7,6 +7,11 @@ owner: Release Integration
 
 | Object                                      | Permission                               |
 | -----------                                 | ------------------------------           |
+| vCenter                                     |                                          |
+|                                             | System.View                              | 
+|                                             | (users can be assigned the Read-Only     |
+|                                             |  role at the vCenter level to gain this  |
+|                                             |  permission)                             |
 | Datastore                                   |                                          |
 |                                             | allocate space                           |
 |                                             | browse datastore                         |


### PR DESCRIPTION
Normally all of the permissions on this page are at the Datacenter object in vCenter.

Per this email thread chain from Dimitri, a change on permissions was made in mid-2015 but not documented that requires a vCenter-wide permission: https://groups.google.com/a/cloudfoundry.org/forum/#!searchin/bosh-users/vsphere$20vcenter$20permission/bosh-users/wtEwmqgasy0/GdWfnAzrCtkJ

Ran into a customer site problem where my CF vSphere user did not have read-only access on the vcenter level and couldn't properly create disks.  It's not clear how to set System.View in the vCenter GUI without just using Read-Only role, so I'm suggesting to users to just add Read-Only.