### PR TITLE
CAPI Blobstore Configuration

### DIFF
--- a/aws/cf-stub.html.md.erb
+++ b/aws/cf-stub.html.md.erb
@@ -11,6 +11,8 @@ Save a copy of the manifest stub as a YAML file in your deployment directory.
 Follow the [editing instructions](#editing) to customize the manifest stub with
 information about your environment.
 
+AWS defaults to using Fog with AWS Credentials for the Cloud Controller blobstore. For alternative blobstore configurations, see <a href="/deploying/common/cc-blobstore-config.html">Cloud Controller Blobstore Configuration</a>.
+
 ##<a id="stub"></a>Cloud Foundry Deployment Manifest Stub for AWS ##
 
 <%= yield_for_code_snippet from: 'cloudfoundry/cf-release', at: 'cf-stub-aws' %>
@@ -130,8 +132,6 @@ properties:
       <br /><br />
       Replace <code>CCDB_ENCRYPTION_KEY</code>
       with a secure key that you generate to encrypt sensitive values in the Cloud Controller database.
-      <br /><br />
-      Cloud Controller uses four blobstores: <code>buildpacks</code>, <code>droplets</code>, <code>packages</code>, and <code>resource_pool</code>. You can edit your manifest stub to configure each blobstore in one of three ways: a blobstore that uses the Fog Ruby gem with AWS credentials, a blobstore that uses the Fog Ruby gem with AWS IAM Instance Profiles, or a blobstore that uses the WebDAV protocol. Review the <a href="#config-blobstores">Configuring Blobstores</a> section for more information.
     </td>
   </tr>
   <tr>
@@ -279,163 +279,4 @@ properties:
     </td>
   </tr>
 </table>
-
-##<a id="config-blobstores"></a>Configuring Blobstores
-
-To configure your blobstores, you must edit the manifest stub.
-
-Cloud Controller uses four blobstores: <code>buildpacks</code>, <code>droplets</code>, <code>packages</code>, and <code>resource_pool</code>. By default, the blobstores use the Fog Ruby gem. To configure a blobstore to use the WebDAV protocol instead, follow the steps under the <a href="#webdav">WebDAV</a> section below.
-
-You can configure your blobstores to use Fog with AWS credentials, Fog with IAM Instance Profiles, or the WebDAV protocol.
-
-###<a id="fog-aws-creds"></a> Fog with AWS Credentials
-
-To use Fog blobstores with AWS credentials, perform the following steps:
-
-1. Insert the following configuration into your manifest stub under `properties.cc`: 
-
-    ```
-    cc:
-      buildpacks:
-        blobstore_type: fog
-        buildpack_directory_key: YOUR-AWS-BLOBSTORE-BUCKET
-        fog_connection: &fog_connection
-          aws_access_key_id: AWS_ACCESS_KEY
-          aws_secret_access_key: AWS_SECRET_ACCESS_KEY
-          provider: AWS
-          region: us-east-1
-      droplets:
-        blobstore_type: fog
-        droplet_directory_key: YOUR-AWS-DROPLET-BUCKET
-        fog_connection: *fog_connection
-      packages:
-        blobstore_type: fog
-        app_package_directory_key: YOUR-AWS-PACKAGE-BUCKET
-        fog_connection: *fog_connection
-      resource_pool:
-        blobstore_type: fog
-        droplet_directory_key: YOUR-AWS-RESOURCE-BUCKET
-        fog_connection: *fog_connection
-    ```
-2. Replace `AWS_ACCESS_KEY` and `AWS_SECRET_ACCESS_KEY` with your AWS credentials, and `YOUR-AWS-BLOBSTORE-BUCKET`, `YOUR-AWS-DROPLET-BUCKET`, `YOUR-AWS-PACKAGE-BUCKET`, `YOUR-AWS-RESOURCE-BUCKET` with the names of your AWS buckets. In the AWS console, you must assign your credentials an IAM policy that allows all S3 actions on all of these buckets.
-
-3. To provide further configuration, create a <code>fog_connection</code> hash to pass through to the Fog gem.
-
-###<a id="fog-aws-iam"></a> Fog with IAM Instance Profiles
-
-To configure Fog blobstores to use <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html">AWS IAM Instance Profiles</a>, perform the following steps:
-
-1. Insert the following configuration into your manifest stub under `properties.cc`:
-
-    ```
-    cc:
-      buildpacks:
-        blobstore_type: fog
-        buildpack_directory_key: YOUR-AWS-BLOBSTORE-BUCKET
-        fog_connection: &fog_connection
-          provider: AWS
-          region: us-east-1
-          use_iam_profile: true
-      droplets:
-        blobstore_type: fog
-        droplet_directory_key: YOUR-AWS-DROPLET-BUCKET
-        fog_connection: *fog_connection
-      packages:
-        blobstore_type: fog
-        app_package_directory_key: YOUR-AWS-PACKAGE-BUCKET
-        fog_connection: *fog_connection
-      resource_pool:
-        blobstore_type: fog
-        droplet_directory_key: YOUR-AWS-RESOURCE-BUCKET
-        fog_connection: *fog_connection
-    ```
-1. Replace `YOUR-AWS-BLOBSTORE-BUCKET`, `YOUR-AWS-DROPLET-BUCKET`, `YOUR-AWS-PACKAGE-BUCKET`, `YOUR-AWS-RESOURCE-BUCKET` with the names of your AWS buckets. To provide further configuration, create a <code>fog_connection</code> hash to pass through to the Fog gem.
-1. Complete the steps documented in the <a href="http://bosh.io/docs/aws-iam-instance-profiles.html#director-with-s3-blobstore">AWS CPI and Director configured with an S3 blobstore instructions</a> section of the BOSH documentation.
-2. In the AWS console, configure an additional <code>cloud-controller</code> IAM role that gives access to both the BOSH S3 buckets and the Cloud Controller S3 buckets specified in your manifest stub:
-<pre><code>
-{
-"Version": "2012-10-17",
-"Statement": [{
-  "Effect": "Allow",
-  "Action": [ "s3:\*" ],
-  "Resource": [
-    "arn:aws:s3:::BOSH\_BUCKET\_NAME",
-    "arn:aws:s3:::BOSH\_BUCKET\_NAME/\*",
-    "arn:aws:s3:::YOUR-AWS-BLOBSTORE-BUCKET",
-    "arn:aws:s3:::YOUR-AWS-BLOBSTORE-BUCKET/\*",
-    "arn:aws:s3:::YOUR-AWS-DROPLET-BUCKET",
-    "arn:aws:s3:::YOUR-AWS-DROPLET-BUCKET/\*",
-    "arn:aws:s3:::YOUR-AWS-PACKAGE-BUCKET",
-    "arn:aws:s3:::YOUR-AWS-PACKAGE-BUCKET/\*",
-    "arn:aws:s3:::YOUR-AWS-RESOURCE-BUCKET",
-    "arn:aws:s3:::YOUR-AWS-RESOURCE-BUCKET/\*",
-  ]
-}]
-}
-</pre></code>
-If you are using the AWS console, an IAM Role is automatically assigned to an IAM Instance Profile with the same name, <code>cloud-controller</code>. If you are not using the AWS console, you must create an IAM Instance Profile with a single assigned IAM Role.
-
-3. In your Cloud Foundry deployment manifest, configure a resource pool to use the <code>cloud-controller</code> IAM Instance Profile:
-  <pre><code>
-  resource\_pools:
-  \- name: cloud-controller-resource-pool
-      network: default
-      stemcell: { ... }
-      cloud\_properties:
-          instance\_type: c3.large
-          iam\_instance\_profile: cloud-controller
-  </code></pre>
-4. Assign all Cloud Controller jobs (<code>api\_z\*</code>) and Cloud Controller Worker jobs (<code>api\_worker\_z\*</code>) to the <code>cloud-controller-resource-pool</code>.
-
-###<a id="webdav"></a>WebDAV
-
-To configure your blobstores to use the WebDAV protocol, perform the following steps:
-
-1. Insert the following configuration into your manifest stub under `properties.blobstore` and `properties.cc`:
-
-    ```
-    blobstore:
-      admin_users:
-      - password: WEBDAV_BASIC_AUTH_PASSWORD
-        username: WEBDAV_BASIC_AUTH_USER
-      port: 80
-      secure_link:
-        secret: WEBDAV_SECRET
-      tls:
-        cert: WEBDAV_CERT
-        port: 443
-        private_key: WEBDAV_PRIVATE_KEY
-        ca_cert: WEBDAV_CA_CERT_BUNDLE
-    cc:
-      buildpacks:
-        blobstore_type: webdav
-        buildpack_directory_key: cc-buildpacks
-        webdav_config: &webdav_config
-          public_endpoint: WEBDAV_PUBLIC_ENDPOINT
-          private_endpoint: WEBDAV_PRIVATE_ENDPOINT
-          username: WEBDAV_BASIC_AUTH_USER
-          password: WEBDAV_BASIC_AUTH_PASSWORD
-          ca_cert: WEBDAV_CA_CERT_BUNDLE
-      droplets:
-        blobstore_type: webdav
-        droplet_directory_key: cc-droplets
-        webdav_config: *webdav_config
-      packages:
-        blobstore_type: webdav
-        app_package_directory_key: cc-packages
-        webdav_config: *webdav_config
-      resource_pool:
-        blobstore_type: webdav
-        droplet_directory_key: cc-resources
-        webdav_config: *webdav_config
-    ```
-
-1. Configure your WebDAV blobstores by performing the following steps:
-      * Replace <code>WEBDAV\_BASIC\_AUTH\_USER</code> and <code>WEBDAV\_BASIC\_AUTH\_PASSWORD</code> with Basic AUTH credentials that Cloud Controller can use to talk your WebDAV installation.
-      * Replace <code>WEBDAV\_SECRET</code> with a secret phrase used to sign URLs.
-      * Replace <code>WEBDAV\_CERT</code>, <code>WEBDAV\_PRIVATE\_KEY</code>, and <code>WEBDAV\_CA\_CERT\_BUNDLE</code> with proper TLS configuration that will be used for the internal blobstore.
-      * Replace <code>WEBDAV\_PUBLIC\_ENDPOINT</code> with the public URL (e.g. https://blobstore.SYSTEM_DOMAIN) that resolves to your WebDAV installation.
-      * Replace <code>WEBDAV\_PRIVATE\_ENDPOINT</code> with a URL routable on your internal network. This defaults to https://blobstore.service.cf.internal if not set.
-      * Replace <code>WEBDAV\_BASIC\_AUTH\_USER</code> and <code>WEBDAV\_BASIC\_AUTH\_PASSWORD</code> with Basic AUTH credentials that Cloud Controller can use to talk your WebDAV installation.
-1. To provide further configuration, create a <code>webnav\_config</code> hash.
 

--- a/common/cc-blobstore-config.html.md.erb
+++ b/common/cc-blobstore-config.html.md.erb
@@ -1,0 +1,165 @@
+---
+title: Cloud Controller Blobstore Configuration
+owner: CAPI
+---
+
+<strong><%= modified_date %></strong>
+
+This topic describes the various options for configuring a blobstore for the Cloud Controller.
+
+Cloud Controller has four types of objects that need to be stored in a blobstore: <code>buildpacks</code>, <code>droplets</code>, <code>packages</code>, and <code>resource_pool</code>. By default, the blobstore configuration uses the Fog Ruby gem, but can also use the WebDAV protocol.
+
+This document demonstrates three common blobstore configurations: Fog with AWS Credentials, Fog with AWS IAM Instance Profiles, and the WebDAV internal blobstore.
+
+##<a id="fog-aws-creds"></a> Fog with AWS Credentials
+
+To use Fog blobstores with AWS credentials, perform the following steps:
+
+1. Insert the following configuration into your manifest under `properties.cc`: 
+
+    ```
+    cc:
+      buildpacks:
+        blobstore_type: fog
+        buildpack_directory_key: YOUR-AWS-BUILDPACK-BUCKET
+        fog_connection: &fog_connection
+          aws_access_key_id: AWS_ACCESS_KEY
+          aws_secret_access_key: AWS_SECRET_ACCESS_KEY
+          provider: AWS
+          region: us-east-1
+      droplets:
+        blobstore_type: fog
+        droplet_directory_key: YOUR-AWS-DROPLET-BUCKET
+        fog_connection: *fog_connection
+      packages:
+        blobstore_type: fog
+        app_package_directory_key: YOUR-AWS-PACKAGE-BUCKET
+        fog_connection: *fog_connection
+      resource_pool:
+        blobstore_type: fog
+        droplet_directory_key: YOUR-AWS-RESOURCE-BUCKET
+        fog_connection: *fog_connection
+    ```
+1. Replace `AWS_ACCESS_KEY` and `AWS_SECRET_ACCESS_KEY` with your AWS credentials, and `YOUR-AWS-BUILDPACK-BUCKET`, `YOUR-AWS-DROPLET-BUCKET`, `YOUR-AWS-PACKAGE-BUCKET`, `YOUR-AWS-RESOURCE-BUCKET` with the names of your AWS buckets. In the AWS console, you must assign your credentials an IAM policy that allows all S3 actions on all of these buckets.
+
+1. Further configuration can be provided through the <code>fog_connection</code> hash, which is passed through to the Fog gem.
+
+##<a id="fog-aws-iam"></a> Fog with AWS IAM Instance Profiles
+
+To configure Fog blobstores to use <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html">AWS IAM Instance Profiles</a>, perform the following steps:
+
+1. Insert the following configuration into your manifest under `properties.cc`:
+
+    ```
+    cc:
+      buildpacks:
+        blobstore_type: fog
+        buildpack_directory_key: YOUR-AWS-BUILDPACK-BUCKET
+        fog_connection: &fog_connection
+          provider: AWS
+          region: us-east-1
+          use_iam_profile: true
+      droplets:
+        blobstore_type: fog
+        droplet_directory_key: YOUR-AWS-DROPLET-BUCKET
+        fog_connection: *fog_connection
+      packages:
+        blobstore_type: fog
+        app_package_directory_key: YOUR-AWS-PACKAGE-BUCKET
+        fog_connection: *fog_connection
+      resource_pool:
+        blobstore_type: fog
+        droplet_directory_key: YOUR-AWS-RESOURCE-BUCKET
+        fog_connection: *fog_connection
+    ```
+1. Replace `YOUR-AWS-BUILDPACK-BUCKET`, `YOUR-AWS-DROPLET-BUCKET`, `YOUR-AWS-PACKAGE-BUCKET`, `YOUR-AWS-RESOURCE-BUCKET` with the names of your AWS buckets. To provide further configuration, create a <code>fog_connection</code> hash to pass through to the Fog gem.
+1. Complete the steps documented in the <a href="http://bosh.io/docs/aws-iam-instance-profiles.html#director-with-s3-blobstore">AWS CPI and Director configured with an S3 blobstore instructions</a> section of the BOSH documentation.
+1. In the AWS console, configure an additional <code>cloud-controller</code> IAM role that gives access to both the BOSH S3 buckets and the Cloud Controller S3 buckets specified in your manifest:
+<pre><code>
+{
+"Version": "2012-10-17",
+"Statement": [{
+  "Effect": "Allow",
+  "Action": [ "s3:\*" ],
+  "Resource": [
+    "arn:aws:s3:::BOSH\_BUCKET\_NAME",
+    "arn:aws:s3:::BOSH\_BUCKET\_NAME/\*",
+    "arn:aws:s3:::YOUR-AWS-BUILDPACK-BUCKET",
+    "arn:aws:s3:::YOUR-AWS-BUILDPACK-BUCKET/\*",
+    "arn:aws:s3:::YOUR-AWS-DROPLET-BUCKET",
+    "arn:aws:s3:::YOUR-AWS-DROPLET-BUCKET/\*",
+    "arn:aws:s3:::YOUR-AWS-PACKAGE-BUCKET",
+    "arn:aws:s3:::YOUR-AWS-PACKAGE-BUCKET/\*",
+    "arn:aws:s3:::YOUR-AWS-RESOURCE-BUCKET",
+    "arn:aws:s3:::YOUR-AWS-RESOURCE-BUCKET/\*",
+  ]
+}]
+}
+</pre></code>
+If you are using the AWS console, an IAM Role is automatically assigned to an IAM Instance Profile with the same name, <code>cloud-controller</code>. If you are not using the AWS console, you must create an IAM Instance Profile with a single assigned IAM Role.
+
+1. In your Cloud Foundry deployment manifest, configure a resource pool to use the <code>cloud-controller</code> IAM Instance Profile:
+  <pre><code>
+  resource\_pools:
+  \- name: cloud-controller-resource-pool
+      network: default
+      stemcell: { ... }
+      cloud\_properties:
+          instance\_type: c3.large
+          iam\_instance\_profile: cloud-controller
+  </code></pre>
+1. Assign all Cloud Controller jobs (<code>api\_z\*</code>) and Cloud Controller Worker jobs (<code>api\_worker\_z\*</code>) to the <code>cloud-controller-resource-pool</code>.
+
+##<a id="webdav"></a>WebDAV
+
+To configure your blobstores to use the WebDAV protocol, perform the following steps:
+
+1. Be sure your deployment manifest has a single instance of the blobstore job. At the time of this writing, you can find a working example in the [example bosh-lite manifest](https://github.com/cloudfoundry/cf-release/blob/49a94e2/spec/fixtures/bosh-lite/cf-manifest.yml#L297-L329).
+1. Insert the following configuration into your manifest under `properties.blobstore` and `properties.cc`:
+
+    ```
+    blobstore:
+      admin_users:
+      - password: WEBDAV_BASIC_AUTH_PASSWORD
+        username: WEBDAV_BASIC_AUTH_USER
+      port: 80
+      secure_link:
+        secret: WEBDAV_SECRET
+      tls:
+        cert: WEBDAV_CERT
+        port: 443
+        private_key: WEBDAV_PRIVATE_KEY
+        ca_cert: WEBDAV_CA_CERT_BUNDLE
+    cc:
+      buildpacks:
+        blobstore_type: webdav
+        buildpack_directory_key: cc-buildpacks
+        webdav_config: &webdav_config
+          public_endpoint: WEBDAV_PUBLIC_ENDPOINT
+          private_endpoint: WEBDAV_PRIVATE_ENDPOINT
+          username: WEBDAV_BASIC_AUTH_USER
+          password: WEBDAV_BASIC_AUTH_PASSWORD
+          ca_cert: WEBDAV_CA_CERT_BUNDLE
+      droplets:
+        blobstore_type: webdav
+        droplet_directory_key: cc-droplets
+        webdav_config: *webdav_config
+      packages:
+        blobstore_type: webdav
+        app_package_directory_key: cc-packages
+        webdav_config: *webdav_config
+      resource_pool:
+        blobstore_type: webdav
+        droplet_directory_key: cc-resources
+        webdav_config: *webdav_config
+    ```
+
+1. Configure your WebDAV blobstores by performing the following steps:
+      * Replace <code>WEBDAV\_BASIC\_AUTH\_USER</code> and <code>WEBDAV\_BASIC\_AUTH\_PASSWORD</code> with Basic AUTH credentials that Cloud Controller can use to talk your WebDAV installation.
+      * Replace <code>WEBDAV\_SECRET</code> with a secret phrase used to sign URLs.
+      * Replace <code>WEBDAV\_CERT</code>, <code>WEBDAV\_PRIVATE\_KEY</code>, and <code>WEBDAV\_CA\_CERT\_BUNDLE</code> with proper TLS configuration that will be used for the internal blobstore.
+      * Replace <code>WEBDAV\_PUBLIC\_ENDPOINT</code> with the public URL (e.g. https://blobstore.SYSTEM_DOMAIN) that resolves to your WebDAV installation.
+      * Replace <code>WEBDAV\_PRIVATE\_ENDPOINT</code> with a URL routable on your internal network. This defaults to https://blobstore.service.cf.internal if not set.
+      * Replace <code>WEBDAV\_BASIC\_AUTH\_USER</code> and <code>WEBDAV\_BASIC\_AUTH\_PASSWORD</code> with Basic AUTH credentials that Cloud Controller can use to talk your WebDAV installation.
+1. To provide further configuration, create a <code>webnav\_config</code> hash.
+

--- a/common/vsphere-vcloud-cf-stub.html.md.erb
+++ b/common/vsphere-vcloud-cf-stub.html.md.erb
@@ -10,6 +10,8 @@ for vSphere, vCloud Air, or vCloud Director.  Follow the
 [editing instructions](#editing) to customize the manifest stub with information
 about your environment.
 
+vSphere defaults to using an internal WebDAV blobstore for the Cloud Controller. For alternative blobstore configurations, see <a href="/deploying/common/cc-blobstore-config.html">Cloud Controller Blobstore Configuration</a>.
+
 ##<a id="stub"></a>Cloud Foundry Deployment Manifest Stub ##
 
 <%= yield_for_code_snippet from: 'cloudfoundry/cf-release', at: 'cf-stub-vsphere' %>

--- a/openstack/cf-stub.html.md.erb
+++ b/openstack/cf-stub.html.md.erb
@@ -14,6 +14,8 @@ Save a copy of the manifest stub as a YAML file in your deployment directory.
 Follow the [editing instructions](#editing) to customize the manifest stub with
 information about your environment.
 
+OpenStack defaults to using an internal WebDAV blobstore for the Cloud Controller. For alternative blobstore configurations, see <a href="/deploying/common/cc-blobstore-config.html">Cloud Controller Blobstore Configuration</a> and <a href="/deploying/openstack/using_swift_blobstore.html">Using OpenStack Swift as a Cloud Foundry Blobstore</a>
+
 ##<a id="stub"></a>Cloud Foundry Deployment Manifest Stub for OpenStack ##
 
 <%= yield_for_code_snippet from: 'cloudfoundry/cf-release', at: 'cf-stub-openstack' %>

--- a/toc.html.md.erb
+++ b/toc.html.md.erb
@@ -15,6 +15,8 @@ title: Deploying Cloud Foundry
 
 * [Deploying Community Services](https://github.com/cloudfoundry-community/cf-services-contrib-release)
 
+* [Cloud Controller Blobstore Configuration](./common/cc-blobstore-config.html)
+
 ___
 
 ## <a id='aws'></a>AWS ##


### PR DESCRIPTION
* Simplify AWS stub customization by making a new page for alternative
blobstore configurations.
* Link to alternative from TOC, AWS, vSphere, and OpenStack stub
customization pages

Depends on https://github.com/cloudfoundry/docs-book-cloudfoundry/pull/46

cc @Amit-PivotalLabs for approval

[#119478309]