### PR TITLE
Recommend user to not use dots in AWS bucket names

### DIFF
--- a/common/cc-blobstore-config.html.md.erb
+++ b/common/cc-blobstore-config.html.md.erb
@@ -15,7 +15,7 @@ This document demonstrates three common blobstore configurations: Fog with AWS C
 
 To use Fog blobstores with AWS credentials, perform the following steps:
 
-1. Insert the following configuration into your manifest under `properties.cc`: 
+1. Insert the following configuration into your manifest under `properties.cc`:
 
     ```
     cc:
@@ -40,7 +40,7 @@ To use Fog blobstores with AWS credentials, perform the following steps:
         resource_directory_key: YOUR-AWS-RESOURCE-BUCKET
         fog_connection: *fog_connection
     ```
-1. Replace `AWS_ACCESS_KEY` and `AWS_SECRET_ACCESS_KEY` with your AWS credentials, and `YOUR-AWS-BUILDPACK-BUCKET`, `YOUR-AWS-DROPLET-BUCKET`, `YOUR-AWS-PACKAGE-BUCKET`, `YOUR-AWS-RESOURCE-BUCKET` with the names of your AWS buckets. In the AWS console, you must assign your credentials an IAM policy that allows all S3 actions on all of these buckets.
+1. Replace `AWS_ACCESS_KEY` and `AWS_SECRET_ACCESS_KEY` with your AWS credentials, and `YOUR-AWS-BUILDPACK-BUCKET`, `YOUR-AWS-DROPLET-BUCKET`, `YOUR-AWS-PACKAGE-BUCKET`, `YOUR-AWS-RESOURCE-BUCKET` with the names of your AWS buckets. We recommend you to not use dots (`.`) in your AWS bucket names. In the AWS console, you must assign your credentials an IAM policy that allows all S3 actions on all of these buckets.
 
 1. Further configuration can be provided through the <code>fog_connection</code> hash, which is passed through to the Fog gem.
 
@@ -72,7 +72,7 @@ To configure Fog blobstores to use <a href="http://docs.aws.amazon.com/IAM/lates
         resource_directory_key: YOUR-AWS-RESOURCE-BUCKET
         fog_connection: *fog_connection
     ```
-1. Replace `YOUR-AWS-BUILDPACK-BUCKET`, `YOUR-AWS-DROPLET-BUCKET`, `YOUR-AWS-PACKAGE-BUCKET`, `YOUR-AWS-RESOURCE-BUCKET` with the names of your AWS buckets. To provide further configuration, create a <code>fog_connection</code> hash to pass through to the Fog gem.
+1. Replace `YOUR-AWS-BUILDPACK-BUCKET`, `YOUR-AWS-DROPLET-BUCKET`, `YOUR-AWS-PACKAGE-BUCKET`, `YOUR-AWS-RESOURCE-BUCKET` with the names of your AWS buckets. We recommend you to not use dots (`.`) in your AWS bucket names. To provide further configuration, create a <code>fog_connection</code> hash to pass through to the Fog gem.
 1. Complete the steps documented in the <a href="http://bosh.io/docs/aws-iam-instance-profiles.html#director-with-s3-blobstore">AWS CPI and Director configured with an S3 blobstore instructions</a> section of the BOSH documentation.
 1. In the AWS console, configure an additional <code>cloud-controller</code> IAM role that gives access to both the BOSH S3 buckets and the Cloud Controller S3 buckets specified in your manifest:
 <pre><code>


### PR DESCRIPTION
This is for both compatibility and performance reasons, and a mistake we
made ourselves multiple times. Fog warns you about the performance if
you decide to do it anyways:

```
[fog][WARNING] fog: the specified s3 bucket name(cfapps.io-cc-buildpacks)
contains a '.' so is not accessible over https as a virtual hosted bucket,
which will negatively impact performance. For details see:
http://docs.amazonwebservices.com/AmazonS3/latest/dev/BucketRestrictions.html
```

Related reads:
- https://github.com/cloudfoundry/cloud_controller_ng/issues/175#issuecomment-36576520
- https://github.com/cloudfoundry/cf-release/pull/573
- https://groups.google.com/a/cloudfoundry.org/forum/#!topic/vcap-dev/h4ZwbAQDyEw
- https://groups.google.com/a/cloudfoundry.org/forum/#!topic/bosh-users/0waAA386RuI
- https://github.com/cloudfoundry/cf-release/pull/312