### PR TITLE
Add a friendly warning about the db_scheme for a Postgres database

### DIFF
--- a/aws/cf-stub.html.md.erb
+++ b/aws/cf-stub.html.md.erb
@@ -262,7 +262,7 @@ properties:
       <br /><br />
       If you used <code>bosh aws create</code>, you can find the necessary values in the generated file <code>aws_rds_bosh_receipt.yml</code>. The database is an Amazon RDS instance, and the <code>UAADB_*</code> values in the stub must match the scheme, username, password, address, and port defined by AWS.
       <br /><br />
-      If you deployed your database without <code>bosh aws create</code>, such as using the <code>postgres</code> job in cf-release, the <code>CCDB_*</code> values must match the configuration of the database node.
+      If you deployed your database without <code>bosh aws create</code>, such as using the <code>postgres</code> job in cf-release, the <code>UAADB_*</code> values must match the configuration of the database node.
 	  </td>
   </tr>
   <tr>

--- a/aws/cf-stub.html.md.erb
+++ b/aws/cf-stub.html.md.erb
@@ -154,6 +154,8 @@ properties:
       If you used <code>bosh aws create</code>, find the necessary values in the generated file <code>aws_rds_bosh_receipt.yml</code>. The database is an Amazon RDS instance, and the <code>CCDB_*</code> values in the stub must match the scheme, username, password, address, and port defined by AWS.
       <br /><br />
       If you deployed your database without <code>bosh aws create</code>, such as using the <code>postgres</code> job in cf-release, the <code>CCDB_*</code> values must match the configuration of the database node.
+      <br /><br />
+      Please mind that the <code>db_scheme</code> for a Postgres database is <code>postgresql</code> and not <code>postgres</code>.
 	  </td>
   </tr>
   <tr>
@@ -263,6 +265,8 @@ properties:
       If you used <code>bosh aws create</code>, you can find the necessary values in the generated file <code>aws_rds_bosh_receipt.yml</code>. The database is an Amazon RDS instance, and the <code>UAADB_*</code> values in the stub must match the scheme, username, password, address, and port defined by AWS.
       <br /><br />
       If you deployed your database without <code>bosh aws create</code>, such as using the <code>postgres</code> job in cf-release, the <code>UAADB_*</code> values must match the configuration of the database node.
+      <br /><br />
+      Please mind that the <code>db_scheme</code> for a Postgres database is <code>postgresql</code> and not <code>postgres</code>.
 	  </td>
   </tr>
   <tr>


### PR DESCRIPTION
This will give the user some headaches and breaks deployment for at least the `uaadb` and `ccdb` with pretty vague errors, another mistake we made ourselves.
