### PR TITLE
Replace the tab with spaces in openstack/cf-stub.html.md.erb

### DIFF
--- a/openstack/cf-stub.html.md.erb
+++ b/openstack/cf-stub.html.md.erb
@@ -142,8 +142,8 @@ properties:
     password: NATS_PASSWORD
     </code></pre></td>
     <td>Replace <code>NATS_USER</code> and
-		<code>NATS_PASSWORD</code> with a username and secure password of your choosing. Cloud Foundry components use these credentials to communicate with each other over the NATS message bus.
-	  </td>
+        <code>NATS_PASSWORD</code> with a username and secure password of your choosing. Cloud Foundry components use these credentials to communicate with each other over the NATS message bus.
+      </td>
   </tr>
   <tr>
     <td><pre><code>
@@ -154,8 +154,8 @@ properties:
     </code></pre></td>
     <td>
       Replace <code>ROUTER_USER</code> and
-  		<code>ROUTER_PASSWORD</code> with a username and secure password of your choosing.
-	  </td>
+        <code>ROUTER_PASSWORD</code> with a username and secure password of your choosing.
+      </td>
   </tr>
   <tr>
     <td><pre><code>


### PR DESCRIPTION
Spaces, it is aligned to view code with any editor, including the web page view (such as in the GitHub code). When use tabs, the view on the page is chaos, and it is terrible to mix tabs and spaces.