### PR TITLE
Replace the tab with spaces

### DIFF
--- a/aws/cf-stub.html.md.erb
+++ b/aws/cf-stub.html.md.erb
@@ -71,13 +71,13 @@ networks:
         security_groups:
           - cf
         subnet: (( properties.template_only.aws.subnet_ids.cf2 ))
-	  </code></pre></td>
+      </code></pre></td>
     <td>If you used <code>bosh aws create</code> to set up your AWS environment, change the IP addresses here if needed to fit the subnet range from your bosh.yml file.
     <br/><br/>
     This example assumes you have two subnets in your AWS VPC with CIDRs <code>10.10.16.0/20</code> and <code>10.10.80.0/20</code> respectively. Update the values for <code>range</code>, <code>reserved</code>, <code>static</code>, and <code>gateway</code> accordingly if the CIDRs for your subnets are different.
     <br/><br/>
     This also assumes that you have a security group <code>cf</code> suitable for your Cloud Foundry VMs. Change this too if the name of your security group is different.
-	  </td>
+      </td>
   </tr>
   <tr>
     <td><pre><code>
@@ -91,7 +91,7 @@ properties:
       subnet_ids:
         cf1: SUBNET_ID_1
         cf2: SUBNET_ID_2
-	  </code></pre></td>
+      </code></pre></td>
     <td>Replace <code>AWS_ACCESS_KEY</code> and <code>AWS_SECRET_ACCESS_KEY</code> with AWS credentials to allow Cloud Controller to manage assets in the S3 buckets you have prepared for this deployment.
     <br/><br/>
     Replace <code>ZONE_1</code> and <code>ZONE_2</code> with two EC2 Availability Zones that you want to distribute your deployment across.
@@ -107,7 +107,7 @@ properties:
   system_domain_organization: SYSTEM_DOMAIN_ORGANIZATION
   app_domains:
    - APP_DOMAIN
-	  </code></pre></td>
+      </code></pre></td>
     <td>Replace <code>SYSTEM_DOMAIN</code> with the domain to be used for all system components. For instance, the Cloud Controller API will be reachable via <code>api.SYSTEM_DOMAIN</code>. Replace <code>APP_DOMAIN</code> with the domain you want associated with applications pushed to your Cloud Foundry installation. For instance, if you push <code>my-app</code> it will be reachable via <code>my-app.APP_DOMAIN</code>.
     <br/><br/>
     It is generally advised to have separate values for <code>SYSTEM_DOMAIN</code> and <code>APP_DOMAIN</code>, e.g. <code>sys.cloud-09.cf-app.com</code> and <code>apps.cloud-09.cf-app.com</code>. For simple deployments, you can use the same domain for both, e.g. <code>cloud-09.cf-app.com</code>. However, you cannot have one domain property extend the other, e.g. you cannot have your <code>SYSTEM_DOMAIN</code> set to <code>cloud-09.cf-app.com</code> and your <code>APP_DOMAIN</code> set to <code>apps.cloud-09.cf-app.com</code>.
@@ -154,7 +154,7 @@ properties:
       If you used <code>bosh aws create</code>, find the necessary values in the generated file <code>aws_rds_bosh_receipt.yml</code>. The database is an Amazon RDS instance, and the <code>CCDB_*</code> values in the stub must match the scheme, username, password, address, and port defined by AWS.
       <br /><br />
       If you deployed your database without <code>bosh aws create</code>, such as using the <code>postgres</code> job in cf-release, the <code>CCDB_*</code> values must match the configuration of the database node. If you are using PostgreSQL, your database must have the required extensions available for Cloud Foundry: <code>uuid-ossp</code>, <code>pgcrypto</code>, and <code>citext</code>. The <code>db_scheme</code> for a PostgreSQL database is <code>postgresql</code>, not <code>postgres</code>.
-	  </td>
+      </td>
   </tr>
   <tr>
     <td><pre><code>
@@ -166,9 +166,9 @@ properties:
     server_key: CONSUL_SERVER_KEY
     agent_cert: CONSUL_AGENT_CERT
     agent_key: CONSUL_AGENT_KEY
-	  </code></pre></td>
+      </code></pre></td>
     <td>See the instructions on <a href="../common/consul-security.html">security configuration for consul</a>.
-	  </td>
+      </td>
   </tr>
   <tr>
     <td><pre><code>
@@ -176,17 +176,17 @@ properties:
     shared_secret: LOGGREGATOR_ENDPOINT_SHARED_SECRET
     </code></pre></td>
     <td>Generate a string secret and replace <code>LOGGREGATOR_ENDPOINT_SHARED_SECRET</code>.
-	  </td>
+      </td>
   </tr>
   <tr>
     <td><pre><code>
   nats:
     user: NATS_USER
     password: NATS_PASSWORD
-	  </code></pre></td>
+      </code></pre></td>
     <td>Replace <code>NATS_USER</code> and
-		<code>NATS_PASSWORD</code> with a username and secure password of your choosing. Cloud Foundry components use these credentials to communicate with each other over the NATS message bus.
-	  </td>
+        <code>NATS_PASSWORD</code> with a username and secure password of your choosing. Cloud Foundry components use these credentials to communicate with each other over the NATS message bus.
+      </td>
   </tr>
   <tr>
     <td><pre><code>
@@ -194,11 +194,11 @@ properties:
     status:
       user: ROUTER_USER
       password: ROUTER_PASSWORD
-	  </code></pre></td>
+      </code></pre></td>
     <td>
       Replace <code>ROUTER_USER</code> and
-  		<code>ROUTER_PASSWORD</code> with a username and secure password of your choosing.
-	  </td>
+        <code>ROUTER_PASSWORD</code> with a username and secure password of your choosing.
+      </td>
   </tr>
   <tr>
     <td><pre><code>
@@ -222,7 +222,7 @@ properties:
         secret: NOTIFICATIONS_CLIENT_SECRET
     </code></pre></td>
     <td>Replace all the <code>*_SECRET</code>s with secure secrets that you generate.
-	  </td>
+      </td>
   </tr>
   <tr>
     <td><pre><code>
@@ -256,14 +256,14 @@ properties:
         name: uaadb
     address: UAADB_ADDRESS
     port: UAADB_PORT
-	  </code></pre></td>
+      </code></pre></td>
     <td>
       This section of the stub defines how the UAA connects to its database. The values depend on how you deployed your database.
       <br /><br />
       If you used <code>bosh aws create</code>, find the necessary values in the generated file <code>aws_rds_bosh_receipt.yml</code>. The database is an Amazon RDS instance, and the <code>UAADB_*</code> values in the stub must match the scheme, username, password, address, and port defined by AWS.
       <br /><br />
       If you deployed your database without <code>bosh aws create</code>, such as using the <code>postgres</code> job in cf-release, the <code>UAADB_*</code> values must match the configuration of the database node. If you are using PostgreSQL, your database must have the required extensions available for Cloud Foundry: <code>uuid-ossp</code>, <code>pgcrypto</code>, and <code>citext</code>. The <code>db_scheme</code> for a PostgreSQL database is <code>postgresql</code>, not <code>postgres</code>.
-	  </td>
+      </td>
   </tr>
   <tr>
     <td><pre><code>

--- a/common/create_a_manifest.html.md.erb
+++ b/common/create_a_manifest.html.md.erb
@@ -71,13 +71,13 @@ manifest, run the update script to fetch all the submodules.
 1. Install [spiff](https://github.com/cloudfoundry-incubator/spiff).
 
 1. The following command, run from the `cf-release` directory, creates a deployment manifest named `cf-deployment.yml`.
-	<pre class="terminal">
-	$ ./scripts/generate\_deployment\_manifest IAAS MANIFEST-STUB > cf-deployment.yml
-	</pre>
+    <pre class="terminal">
+    $ ./scripts/generate\_deployment\_manifest IAAS MANIFEST-STUB > cf-deployment.yml
+    </pre>
 Replace `IAAS` with either `aws`, `openstack`, or `vsphere`.  Note that `vsphere` works for vSphere, vCloud Air, and vCloud Director. Replace `MANIFEST-STUB` with the location of your `cf-stub.yml` file. For example:
 
     <pre class="terminal">
-	$ ./scripts/generate_deployment_manifest vsphere ../cf-stub.yml > cf-deployment.yml
+    $ ./scripts/generate_deployment_manifest vsphere ../cf-stub.yml > cf-deployment.yml
     </pre>
 
     <p class="note"><strong>Note</strong>: The <code>generate_deployment_manifest</code> script can accept multiple stub files. For example, the following command passes two stub files to the script: <br/>

--- a/common/deploy.html.md.erb
+++ b/common/deploy.html.md.erb
@@ -76,7 +76,7 @@ should show as **running**.
     </pre>
 
     If `curl` succeeds, it should return specific JSON-formatted information about your deployment. If `curl` does not succeed, check your networking and make sure your domain
-  	has an NS record for your subdomain.
+    has an NS record for your subdomain.
     <br><br>
     If you do not know `YOUR-SYSTEM-DOMAIN` for your Cloud Foundry installation, examine the `system_domain` property in your deployment manifest.
 

--- a/common/vsphere-vcloud-cf-stub.html.md.erb
+++ b/common/vsphere-vcloud-cf-stub.html.md.erb
@@ -137,8 +137,8 @@ properties:
     password: NATS_PASSWORD
     </code></pre></td>
     <td>Replace <code>NATS_USER</code> and
-		<code>NATS_PASSWORD</code> with a username and secure password of your choosing. Cloud Foundry components use these credentials to communicate with each other over the NATS message bus.
-	  </td>
+        <code>NATS_PASSWORD</code> with a username and secure password of your choosing. Cloud Foundry components use these credentials to communicate with each other over the NATS message bus.
+      </td>
   </tr>
   <tr>
     <td><pre><code>
@@ -149,8 +149,8 @@ properties:
     </code></pre></td>
     <td>
       Replace <code>ROUTER_USER</code> and
-  		<code>ROUTER_PASSWORD</code> with a username and secure password of your choosing.
-	  </td>
+        <code>ROUTER_PASSWORD</code> with a username and secure password of your choosing.
+      </td>
   </tr>
   <tr>
     <td><pre><code>

--- a/openstack/required-flavors.html.md.erb
+++ b/openstack/required-flavors.html.md.erb
@@ -12,20 +12,20 @@ with the OpenStack default flavor names `m1.small`, `m1.medium`, `m1.large`, and
 These flavors must have the following listed specifications, at minimum:
     <table class="nice">
       <tr>
-  	    <th>OpenStack Flavor Name</th>
-  	    <th>CPUs</th>
-  	    <th>RAM (GB)</th>
-  	    <th>Disk (GB)</th>
-  	    <th>Ephemeral Disk (GB)</th>
+        <th>OpenStack Flavor Name</th>
+        <th>CPUs</th>
+        <th>RAM (GB)</th>
+        <th>Disk (GB)</th>
+        <th>Ephemeral Disk (GB)</th>
       </tr>
       <tr>
-  	    <td>m1.small</td>
-  	    <td>1</td>
-  	    <td>2</td>
-  	    <td>10</td>
-  	    <td>20</td>
-  	  </tr>
-  	  <tr>
+        <td>m1.small</td>
+        <td>1</td>
+        <td>2</td>
+        <td>10</td>
+        <td>20</td>
+      </tr>
+      <tr>
         <td>m1.medium</td>
         <td>2</td>
         <td>4</td>
@@ -34,16 +34,16 @@ These flavors must have the following listed specifications, at minimum:
       </tr>
       <tr>
         <td>m1.large</td>
-  	    <td>4</td>
-  	    <td>8</td>
-  	    <td>10</td>
-  	    <td>80</td>
-  	  </tr>
+        <td>4</td>
+        <td>8</td>
+        <td>10</td>
+        <td>80</td>
+      </tr>
       <tr>
         <td>m1.xlarge</td>
-  	    <td>8</td>
-  	    <td>16</td>
-  	    <td>10</td>
-  	    <td>160</td>
-  	  </tr>
+        <td>8</td>
+        <td>16</td>
+        <td>10</td>
+        <td>160</td>
+      </tr>
     </table>

--- a/openstack/troubleshooting.html.md.erb
+++ b/openstack/troubleshooting.html.md.erb
@@ -46,11 +46,11 @@ Try the following options to resolve this issue:
 1. (Recommended) Restart the `cloud_controller`, or `api`, jobs with the BOSH CLI `bosh restart cloud_controller`.
 2. Manually recreate the NFS mount on the `cloud_controller` job server:
 
-	<pre class='terminal'>
-	$ bosh ssh cloud_controller/0
-	root:~# umount /var/vcap/nfs
-	root:~# mount -t nfs 0.nfs.default.cf.microbosh:/var/vcap/store /var/vcap/nfs
-	</pre>
+    <pre class='terminal'>
+    $ bosh ssh cloud_controller/0
+    root:~# umount /var/vcap/nfs
+    root:~# mount -t nfs 0.nfs.default.cf.microbosh:/var/vcap/store /var/vcap/nfs
+    </pre>
 
-	Replace `0.nfs.default.cf.microbosh` above with the static IP or DNS host of the job instance running the `debian_nfs_server`.
+    Replace `0.nfs.default.cf.microbosh` above with the static IP or DNS host of the job instance running the `debian_nfs_server`.
 

--- a/openstack/using_swift_blobstore.html.md.erb
+++ b/openstack/using_swift_blobstore.html.md.erb
@@ -26,8 +26,8 @@ retrieve an auth token.
 
     ```
     curl -s -H 'Content-type: application/json' -d '{"auth": {"tenantName":     "TENANT", "passwordCredentials":
-    	{"username": "USER", \"password": "PASSWORD"}}}' https://auth.example.com:5000/v2.0/tokens
-		    | python -mjson.tool
+        {"username": "USER", \"password": "PASSWORD"}}}' https://auth.example.com:5000/v2.0/tokens
+            | python -mjson.tool
     ```
 
 1. Replace YOUR-AUTH-TOKEN, ACCOUNT-META-TEMP-URL-KEY, and YOUR-TENANT-ID in the command below. Run this command to assign an Account-Meta-Temp-URL-Key to your OpenStack account.
@@ -50,21 +50,21 @@ properties:
     ...
     packages:
       app_package_directory_key: cc-packages
-	  fog_connection: &fog_connection
-	    provider: 'OpenStack'
-	    openstack_username: '<user>'
-	    openstack_api_key: '<password>'
-	    openstack_auth_url: 'https://auth.example.com:5000/v2.0/tokens'
-	    openstack_temp_url_key: '<account meta temp url key>'
-	droplets:
-	  droplet_directory_key: cc-droplets
-	  fog_connection: *fog_connection
-	resource_pool:
- 	  resource_directory_key: cc-resources
-	  fog_connection: *fog_connection
-	buildpacks:
-	  buildpack_directory_key: cc-buildpacks
-	  fog_connection: *fog_connection
+      fog_connection: &fog_connection
+        provider: 'OpenStack'
+        openstack_username: '<user>'
+        openstack_api_key: '<password>'
+        openstack_auth_url: 'https://auth.example.com:5000/v2.0/tokens'
+        openstack_temp_url_key: '<account meta temp url key>'
+    droplets:
+      droplet_directory_key: cc-droplets
+      fog_connection: *fog_connection
+    resource_pool:
+      resource_directory_key: cc-resources
+      fog_connection: *fog_connection
+    buildpacks:
+      buildpack_directory_key: cc-buildpacks
+      fog_connection: *fog_connection
 ```
 
 ## Links ##

--- a/vcloud/setup_vcloud.html.md.erb
+++ b/vcloud/setup_vcloud.html.md.erb
@@ -188,7 +188,7 @@ The rest of this documentation assumes you have created this machine in the targ
 4. Once it starts, assign an IP address to the jump box by logging into the VM and assigning a static IP address using [Ubuntu's instructions](https://help.ubuntu.com/10.04/serverguide/network-configuration.html#static-ip-addressing).
 5. Install a set of packages we will need for various purposes during this installation
 
-		sudo apt-get -y install libsqlite3-dev genisoimage libxslt-dev libxml2-dev whois openssl bind9 libpq-dev libmysqlclient-dev
+        sudo apt-get -y install libsqlite3-dev genisoimage libxslt-dev libxml2-dev whois openssl bind9 libpq-dev libmysqlclient-dev
 
 ## <a id="bosh-cli"></a> Install BOSH CLI ##
 


### PR DESCRIPTION
Spaces, it is aligned to view code with any editor, including the web page view (such as in the GitHub code). When use tabs, the view on the page is chaos, and it is terrible to mix tabs and spaces.