### PR TITLE
Update rate limit check description

### DIFF
--- a/openstack/validate_openstack.html.md.erb
+++ b/openstack/validate_openstack.html.md.erb
@@ -135,12 +135,13 @@ Note that you can press `Ctrl-C` to exit the ping program. If you are not able t
 
 Your OpenStack might have API throttling. API throttling can cause BOSH requests to OpenStack to fail while waiting for the API throttle to expire.
 
-Use the following commands to determine if you are affected by API throttling:
+Create a VM and use the following commands to determine if you are affected by API throttling:
 
 <pre class="terminal">
 $ gem install fog
 $ fog openstack
->> 100.times { p Compute[:openstack].servers }
+>> vm = Compute[:openstack].servers.get(VM_UUID)
+>> 100.times { |i| vm.metadata.update('counter' => "#{i}") }
 </pre>
 
 If you are limited by API throttling, you will receive a 413 HTTP response.


### PR DESCRIPTION
GET requests were never throttled. Hence we propose to
execute a POST request.
Updating metadata for an existing server appears to be
more reasonable than e.g. starting VMs.

fixes #105

[#127818083](https://www.pivotaltracker.com/story/show/127818083)
Signed-off-by: Beyhan Veli <beyhan.veli@sap.com>