### PR TITLE
Cloud Controller removed NFS in favor of WebDAV

### DIFF
--- a/openstack/troubleshooting.html.md.erb
+++ b/openstack/troubleshooting.html.md.erb
@@ -25,32 +25,3 @@ dea_next:
 ```
 
 Use `bosh deploy` to push these changes and then reboot your Warden / DEA VM.
-
-## NFS and Cloud Controller
-
-If you get the following error when deploying an app to Cloud Foundry you may have an NFS related issue with the Cloud Controller:
-<pre class='terminal'>
-$ The app package is invalid: failed synchronizing resource pool File exists - /var/vcap/nfs/shared
-</pre>
-
-To confirm that this is related to a broken or incomplete NFS mount, SSH into the `cloud_controller_ng` job and checking the existence of the `/var/vcap/nfs/shared` folder:
-
-<pre class='terminal'>
-$ bosh ssh cloud_controller/0 "ls -l /var/vcap/nfs/shared"
-...
-ls: cannot access /var/vcap/nfs/shared: Stale NFS file handle"
-</pre>
-
-Try the following options to resolve this issue:
-
-1. (Recommended) Restart the `cloud_controller`, or `api`, jobs with the BOSH CLI `bosh restart cloud_controller`.
-2. Manually recreate the NFS mount on the `cloud_controller` job server:
-
-    <pre class='terminal'>
-    $ bosh ssh cloud_controller/0
-    root:~# umount /var/vcap/nfs
-    root:~# mount -t nfs 0.nfs.default.cf.microbosh:/var/vcap/store /var/vcap/nfs
-    </pre>
-
-    Replace `0.nfs.default.cf.microbosh` above with the static IP or DNS host of the job instance running the `debian_nfs_server`.
-


### PR DESCRIPTION
NFS blobstore isn't used anymore in Cloud Controller because of the above problems. The replacement WebDAV blobstore doesn't suffer from the same problems, so let's remove this part.