### PR TITLE
Removing reference to .ruby-version since [it is no longer part of th…

### DIFF
--- a/boshlite/create_a_manifest.html.md.erb
+++ b/boshlite/create_a_manifest.html.md.erb
@@ -61,7 +61,6 @@ manifest, run the update script to fetch all the submodules.
     $ ./scripts/update
     </pre>
 
-1. Install the Ruby version listed in the `.ruby-version` file of the cf-release repository. You can manage your Ruby versions using `rvm`, `rbenv`, or `chruby`.
 1. Run `gem install bundler` to install `bundler`.
 1. Install [spiff](https://github.com/cloudfoundry-incubator/spiff).
 1. Use the `scripts/generate-bosh-lite-dev-manifest` command to create a


### PR DESCRIPTION
Removing reference to .ruby-version since [it is no longer part of the repo](https://github.com/cloudfoundry/cf-release/issues/1025) [#131048969]

