### PR TITLE
Add documents for customizing maniefsts for Azure with stubs

### DIFF
--- a/azure/cf-stub.html.md.erb
+++ b/azure/cf-stub.html.md.erb
@@ -1,0 +1,350 @@
+---
+title: Customizing the Cloud Foundry Deployment Manifest for Azure
+---
+
+<strong><%= modified_date %></strong>
+
+This topic describes how to customize the Cloud Foundry deployment manifest for Azure.
+
+To create a Cloud Foundry manifest, you must perform the following steps:
+
+1. Prepare workspace environment, download cf-release and install spiff.
+1. Use the BOSH CLI to retrieve your BOSH Director UUID, which you use to customize your manifest stub.
+1. Create a manifest stub in YAML format.
+1. Use `spiff` to merge the manifest stub with azure IAAS configuration and other configuration files in the cf-release repository to generate your deployment manifest.
+
+##<a id='preparation'></a> Step 1: Preparation
+
+1. Prepare a work environment
+
+    <pre class="terminal">
+    $ mkdir workspace
+    $ cd workspace
+    $ export WORK_DIR=$(pwd)
+    </pre>
+
+1. Clone the cf-release GitHub repository. Use `git clone` to clone the latest Cloud Foundry configuration files onto your machine.
+
+    <pre class="terminal">
+    $ git clone https://github.com/cloudfoundry/cf-release.git
+    </pre>
+
+1. From the `cf-release` directory, run the update script to fetch all the submodules.
+
+    <pre class="terminal">
+    $ ${WORK_DIR}/cf-release/scripts/update
+    </pre>
+
+1. Install [spiff](https://github.com/cloudfoundry-incubator/spiff), a command line tool for generating deployment manifests.
+
+##<a id='bosh-uuid'></a> Step 2: Retrieve Your BOSH Director UUID
+
+<%= partial '../common/bosh_uuid' %>
+
+##<a id='stub'></a> Step 3: Create Your Manifest Stub
+
+###<a id="example-stub"></a> Get Cloud Foundry Deployment Manifest Stub for Azure
+Get the [example manifest stub](https://raw.githubusercontent.com/cloudfoundry-incubator/bosh-azure-cpi-release/master/docs/stubs/cf/cf-stub.yml) for Azure, and then follow this editing instructions to customize it for your deployment.
+
+###<a id="editing"></a>Editing Instructions
+<table border="1" class="nice">
+  <tr>
+    <th style="width:35%">Deployment Manifest Stub Contents</th>
+    <th>Editing Instructions</th>
+  </tr>
+  <tr>
+    <td><pre><code>
+director_uuid: DIRECTOR_UUID
+    </code></pre></td>
+    <td>Replace <code>DIRECTOR_UUID</code> with the BOSH Director UUID. Use
+    <code>bosh status --uuid</code> to view the BOSH Director UUID.
+    </td>
+  </tr>
+  <tr>
+    <td><pre><code>
+meta:
+  environment: ENVIRONMENT
+    </code></pre></td>
+    <td>Replace <code>ENVIRONMENT</code> with an arbitrary name describing your environment, e.g. <code>azure-prod</code>.
+    </td>
+  </tr>
+  <tr>
+    <td><pre><code>
+  reserved_static_ips:
+  - CLOUD_FOUNDRY_PUBLIC_IP
+    </code></pre></td>
+    <td>Replace <code>CLOUD_FOUNDRY_PUBLIC_IP</code> with an existing public IP address for your Azure network. This is assigned to the <code>ha_proxy</code> job
+    to receive incoming traffic.
+    </td>
+  </tr>
+  <tr>
+    <td><pre><code>
+networks:
+  - name: reserved
+    type: vip
+
+  - name: cf1
+    type: manual
+    subnets:
+    - range: 10.0.16.0/24
+      gateway: 10.0.16.1
+      dns:
+      - 168.63.129.16
+      reserved:
+      - 10.0.16.2 - 10.0.16.3
+      static:
+      - 10.0.16.4 - 10.0.16.100
+      cloud_properties:
+        virtual_network_name: VNET_NAME
+        subnet_name: SUBNET_NAME_FOR_CLOUD_FOUNDRY
+        security_group: NSG_NAME_FOR_CLOUD_FOUNDRY
+    </code></pre></td>
+    <td>Update the values for <code>range</code>, <code>gateway</code>,  <code>reserved</code>, <code>static</code> to reflect the available networks/IPs in your Azure network.  Replace <code>VNET_NAME</code> with virtual network name, <code>SUBNET_NAME_FOR_CLOUD_FOUNDRY</code> with subnet name, <code>NSG_NAME_FOR_CLOUD_FOUNDRY</code> with security group name of your Azure network.
+    </td>
+  </tr>
+  <tr>
+    <td><pre><code>
+properties:
+  system_domain: SYSTEM_DOMAIN
+  system_domain_organization: SYSTEM_DOMAIN_ORGANIZATION
+    </code></pre></td>
+    <td>Replace <code>SYSTEM_DOMAIN</code> with the full domain you want associated with applications pushed to your Cloud Foundry installation. You must have already acquired these domains and configured their DNS records so that these domains resolve to your load balancer. For testing, you can use "CLOUD_FOUNDRY_PUBLIC_IP.xip.io" if you do not have a domain available (Noted that xip.io is not stable and sometime might fail to resolve to related IP).
+    <br/><br/>
+    Put your organization name for the <code>SYSTEM_DOMAIN_ORGANIZATION</code>, this organization will be created and configured to own the <code>SYSTEM_DOMAIN</code>.
+    </td>
+  </tr>
+  <tr>
+    <td><pre><code>
+  ssl:
+    skip_cert_verify: true
+    </code></pre></td>
+    <td> Set <code>skip_cert_verify</code> to <code>true</code> to skip SSL certificate verification if you do not use a real domain and certificate. If you want to use SSL certificates to secure traffic into your deployment, see the <a href="http://docs.cloudfoundry.org/adminguide/securing-traffic.html">Securing Traffic into Cloud Foundry</a> topic.
+  </td>
+  <tr>
+    <td><pre><code>
+  cc:
+    staging_upload_user: STAGING_UPLOAD_USER
+    staging_upload_password: STAGING_UPLOAD_PASSWORD
+    bulk_api_password: BULK_API_PASSWORD
+    db_encryption_key: DB_ENCRYPTION_KEY
+    </code></pre></td>
+    <td>
+    The Cloud Controller API endpoint requires basic authentication. Replace <code>STAGING_UPLOAD_USER</code> and <code>STAGING_UPLOAD_PASSWORD</code> with a username and password of your choosing.
+    <br /><br />
+    Replace <code>BULK_API_PASSWORD</code> with a password of your choosing. Health Manager uses this password to access the Cloud Controller bulk API.
+    <br /><br />
+    Replace <code>DB_ENCRYPTION_KEY</code> with a secure key that you generate to encrypt sensitive values in the Cloud Controller database.
+    You can use any random string. For example, run <code>md5 -qs "$(date)"</code> from a command line to generate a random string using the MD5 Hash Generator.
+    </td>
+  </tr>
+  <tr>
+    <td><pre><code>
+  blobstore:
+    admin_users:
+      - username: BLOBSTORE_USERNAME
+        password: BLOBSTORE_PASSWORD
+    secure_link:
+        secret: BLOBSTORE_SECRET
+    tls:
+        port: 443
+        cert: BLOBSTORE_TLS_CERT
+        private_key: BLOBSTORE_PRIVATE_KEY
+        ca_cert: BLOBSTORE_CA_CERT
+    </code></pre></td>
+    <td>Replace <code>BLOBSTORE_USERNAME</code> and <code>BLOBSTORE_PASSWORD</code> with a username and password of your choosing.
+    <br /><br />
+    Replace <code>BLOBSTORE_SECRET</code> with a secure secret of your choosing.
+    <br /><br />
+    Replace <code>BLOBSTORE_TLS_CERT</code>, <code>BLOBSTORE_PRIVATE_KEY</code>, and <code>BLOBSTORE_CA_CERT</code> with the blobstore TLS certificate, private key, and CA certificate. You can use the <code>${WORK_DIR}/cf-release/scripts/generate-blobstore-certs</code> script in the cf-release repository to generate self signed certs.
+    </td>
+  </tr>
+  <tr>
+    <td><pre><code>
+  consul:
+    encrypt_keys:
+      - CONSUL_ENCRYPT_KEY
+    ca_cert: CONSUL_CA_CERT
+    server_cert: CONSUL_SERVER_CERT
+    server_key: CONSUL_SERVER_KEY
+    agent_cert: CONSUL_AGENT_CERT
+    agent_key: CONSUL_AGENT_KEY
+    </code></pre></td>
+    <td>See the instructions on <a href="http://docs.cloudfoundry.org/deploying/common/consul-security.html">security configuration for consul</a>. You can use the <code>${WORK_DIR}/cf-release/scripts/generate-consul-certs</code> script in the cf-release repository to generate self signed certs.
+    </td>
+  </tr>
+  <tr>
+    <td><pre><code>
+  loggregator_endpoint:
+    shared_secret: LOGGREGATOR_ENDPOINT_SHARED_SECRET
+    </code></pre></td>
+    <td>Generate a string secret and replace <code>LOGGREGATOR_ENDPOINT_SHARED_SECRET</code>.
+    </td>
+  </tr>
+  <tr>
+    <td><pre><code>
+  nats:
+    user: NATS_USER
+    password: NATS_PASSWORD
+    </code></pre></td>
+    <td>Replace <code>NATS_USER</code> and
+        <code>NATS_PASSWORD</code> with a username and secure password of your choosing. Cloud Foundry components use these credentials to communicate with each other over the NATS message bus.
+      </td>
+  </tr>
+  <tr>
+    <td><pre><code>
+  router:
+    status:
+      user: ROUTER_USER
+      password: ROUTER_PASSWORD
+    </code></pre></td>
+    <td>
+      Replace <code>ROUTER_USER</code> and
+        <code>ROUTER_PASSWORD</code> with a username and secure password of your choosing.
+      </td>
+  </tr>
+  <tr>
+    <td><pre><code>
+  uaa:
+    admin:
+      client_secret: ADMIN_SECRET
+    cc:
+      client_secret: CC_CLIENT_SECRET
+    clients:
+      cc_routing:
+        secret: CC_ROUTING_SECRET
+      cloud_controller_username_lookup:
+        secret: CLOUD_CONTROLLER_USERNAME_LOOKUP_SECRET
+      doppler:
+        secret: DOPPLER_SECRET
+      gorouter:
+        secret: GOROUTER_SECRET
+      tcp_emitter:
+        secret: TCP-EMITTER-SECRET
+      tcp_router:
+        secret: TCP-ROUTER-SECRET
+      login:
+        secret: LOGIN_CLIENT_SECRET
+      notifications:
+        secret: NOTIFICATIONS_CLIENT_SECRET
+      cc-service-dashboards:
+        secret: CC_SERVICE_DASHBOARDS_SECRET
+    </code></pre></td>
+    <td>Replace all the <code>*_SECRET</code>s with secure secrets that you generate.
+    </td>
+  </tr>
+  <tr>
+    <td><pre><code>
+    jwt:
+      verification_key: JWT_VERIFICATION_KEY
+      signing_key: JWT_SIGNING_KEY
+    </code></pre></td>
+    <td>Generate a PEM-encoded RSA key pair, and replace <code>JWT_SIGNING_KEY</code> with the private key, and <code>JWT_VERIFICATION_KEY</code> with the corresponding public key. You can generate a key pair by using the command <code>ssh-keygen -f jwt-key.pem</code>. This creates <code>jwt-key.pem.pub</code>, which contains your public key, and <code>jwt-key.pem</code>, which contains your private key.<br/>
+    Paste in the full keys with correct indentation, including the <code>BEGIN</code> and <code>END</code> delimiter lines.
+    </td>
+  </tr>
+  <tr>
+    <td><pre><code>
+    scim:
+      users:
+      - name: admin
+        password: ADMIN_PASSWORD
+        groups:
+        - scim.write
+        - scim.read
+        - openid
+        - cloud_controller.admin
+        - doppler.firehose
+    </code></pre></td>
+    <td>Generate a secure password and replace <code>ADMIN_PASSWORD</code> with that value to set the password for the Admin user of your Cloud Foundry installation.
+    </td>
+  </tr>
+  <tr>
+    <td><pre><code>
+    sslCertificate: UAA_SERVER_CERT
+    sslPrivateKey: UAA_SERVER_KEY
+    </code></pre></td>
+    <td>Replace <code>UAA_SERVER_CERT</code> and <code>UAA_SERVER_KEY</code> with UAA certs, You can use the <code>${WORK_DIR}/cf-release/scripts/generate-uaa-certs</code> script in the cf-release repository to generate self signed certs. </td>
+    </td>
+  </tr>
+  <tr>
+    <td><pre><code>
+  ccdb:
+    roles:
+    - name: ccadmin
+      password: CCDB_PASSWORD
+  uaadb:
+    roles:
+      - name: uaaadmin
+        password: UAADB_PASSWORD
+  databases:
+    roles:
+    - name: ccadmin
+      password: CCDB_PASSWORD
+    - name: uaaadmin
+      password: UAADB_PASSWORD
+    - name: diego
+      password: DIEGODB_PASSWORD
+    </code></pre></td>
+    <td>Replace <code>CCDB_PASSWORD</code>, <code>UAADB_PASSWORD</code> and <code>DIEGODB_PASSWORD</code>with secure passwords of your choosing.
+    </td>
+  </tr>
+  <tr>
+    <td><pre><code>
+  hm9000:
+    ca_cert: HM9000_CA_CERT
+    server_cert: HM9000_SERVER_CERT
+    server_key: HM9000_SERVER_KEY
+    agent_cert: HM9000_AGENT_CERT
+    agent_key: HM9000_AGENT_KEY
+    </code></pre></td>
+    <td>
+      Generate ssl certs for hm9000 and replace these values. You can use the <code>${WORK_DIR}/cf-release/scripts/generate-hm9000-certs</code> script in the cf-release repository to generate self signed certs.
+    </td>
+  </tr>
+  <tr>
+    <td><pre><code>
+jobs:
+  - name: ha_proxy_z1
+    networks:
+      - name: cf1
+        default:
+        - dns
+        - gateway
+    properties:
+      ha_proxy:
+        ssl_pem: |
+          -----BEGIN RSA PRIVATE KEY-----
+          RSA_PRIVATE_KEY
+          -----END RSA PRIVATE KEY-----
+          -----BEGIN CERTIFICATE-----
+          SSL_CERTIFICATE_SIGNED_BY_PRIVATE_KEY
+          -----END CERTIFICATE-----
+    </code></pre></td>
+    <td>Replace <code>RSA_PRIVATE_KEY</code> and <code>SSL_CERTIFICATE_SIGNED_BY_PRIVATE_KEY</code> with the PEM-encoded private key and certificate associated with the system domain and apps domains you have configured to terminate at the floating IP associated with the <code>ha_proxy</code> job. For self-signed certs, you can use <code>openssl genrsa -out haproxy_ssl.key 2048</code> to generate a key, and use <code>openssl req -new -x509 -days 365 -key haproxy_ssl.key -out haproxy_ssl.cert</code> to generate the cert.
+    </td>
+  </tr>
+</table>
+
+<%= partial '../common/additional_config' %>
+
+##<a id='generate'></a>Step 4: Generate Your Manifest
+1. Download Azure infrastructure stub `cf-infrastructure-azure.yml` for Cloud Foundry from this [link](https://raw.githubusercontent.com/cloudfoundry-incubator/bosh-azure-cpi-release/master/docs/stubs/cf/cf-infrastructure-azure.yml). You can also configure IAAS configuration by changing this file, for example changing <code>instance_type</code> and so on.
+1. Run the following command from the `cf-release` directory to create a deployment manifest named `cf-deployment.yml`:
+    <pre class="terminal">
+    $ spiff merge \
+      "${WORK\_DIR}/cf-release/templates/generic-manifest-mask.yml" \
+      "${WORK\_DIR}/cf-release/templates/cf.yml" \
+      "${WORK\_DIR}/cf-infrastructure-azure.yml" \
+      "${WORK\_DIR}/cf-stub.yml" \
+      \> "${WORK\_DIR}/cf-deployment.yml"
+    </pre>
+
+1. Use the `bosh deployment` command to set your deployment to the generated manifest:
+
+    <pre class="terminal">
+    $ bosh deployment ${WORK_DIR}/cf-deployment.yml
+    </pre>
+
+Now you are ready to deploy Cloud Foundry. See the [Deploying Cloud Foundry](http://docs.cloudfoundry.org/deploying/common/deploy.html) topic for instructions.
+
+

--- a/azure/index.html.md.erb
+++ b/azure/index.html.md.erb
@@ -1,0 +1,14 @@
+---
+title: Preparing to Deploy on Azure
+---
+
+<strong><%= modified_date %></strong>
+
+## Step 1: Deploy BOSH ##
+
+* [Initializing BOSH on Azure](https://bosh.io/docs/init-azure.html)
+
+## Step 2: Deploy Cloud Foundry ##
+
+* [Customizing the Cloud Foundry Deployment Manifest Stub for Azure](cf-stub.html)
+* [Deploying Cloud Foundry using BOSH](../common/deploy.html): Deploy!

--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -23,6 +23,7 @@ Cloud Foundry itself.
 Select one of the core supported infrastructures below to get started:
 
 * <a class="subnav" href="./aws/index.html">AWS</a>
+* <a class="subnav" href="./azure/index.html">Azure</a>
 * <a class="subnav" href="./openstack/index.html">OpenStack</a>
 * <a class="subnav" href="./vsphere/index.html">vSphere</a>
 * <a class="subnav" href="./vcloud/index.html">vCloud Air or vCloud Director</a>


### PR DESCRIPTION
Cloud Foundry is already supported in Azure for a while, we would like to add a document for Azure as other clouds about `how to generate/customize a manifest`. Several people had asked for this document.

This PR has
1.  A link to the document about initializing BOSH on Azure
2.  A guide about how to customize manifest on Azure using stubs. 