### PR TITLE
Add description for how to generate login.saml.serviceProviderKey

### DIFF
--- a/aws/cf-stub.html.md.erb
+++ b/aws/cf-stub.html.md.erb
@@ -270,6 +270,25 @@ properties:
   </tr>
   <tr>
     <td><pre><code>
+    login:
+      saml:
+        serviceProviderKey:  |
+          -----BEGIN RSA PRIVATE KEY-----
+          MIICabcdefabcdefabcdefabcdef
+          MIICabcdefabcdefabcdefabcdef
+          MIICabcdefabcdefabcdefabcdef
+          MIICabcdefabcdefabcdefabcdef
+          MIICabcdefabcdefabcdefabcdef
+          MIICabcdefabcdefabcdefabcdef
+          MIICabcdefabcdefabcdefabcdef==
+          -----END RSA PRIVATE KEY-----
+    </code></pre></td>
+    <td>Generate a PEM-encoded RSA key pair. You can generate a key pair by running the command <code>openssl req -x509 -nodes -newkey rsa:2048 -days 365 -keyout key.pem -out cert.pem</code>. This command creates <code>cert.pem</code>, which contains your public key, and <code>key.pem</code>, which contains your private key. Copy in the full private key, including the <code>BEGIN</code> and <code>END</code> delimiter lines, under <code>serviceProviderKey</code>.</br>
+    For RSA keys, you only need to configure the private key.
+    </td>
+  </tr>
+  <tr>
+    <td><pre><code>
     scim:
       users:
       - name: admin

--- a/azure/cf-stub.html.md.erb
+++ b/azure/cf-stub.html.md.erb
@@ -256,6 +256,25 @@ properties:
   </tr>
   <tr>
     <td><pre><code>
+    login:
+      saml:
+        serviceProviderKey:  |
+          -----BEGIN RSA PRIVATE KEY-----
+          MIICabcdefabcdefabcdefabcdef
+          MIICabcdefabcdefabcdefabcdef
+          MIICabcdefabcdefabcdefabcdef
+          MIICabcdefabcdefabcdefabcdef
+          MIICabcdefabcdefabcdefabcdef
+          MIICabcdefabcdefabcdefabcdef
+          MIICabcdefabcdefabcdefabcdef==
+          -----END RSA PRIVATE KEY-----
+    </code></pre></td>
+    <td>Generate a PEM-encoded RSA key pair. You can generate a key pair by running the command <code>openssl req -x509 -nodes -newkey rsa:2048 -days 365 -keyout key.pem -out cert.pem</code>. This command creates <code>cert.pem</code>, which contains your public key, and <code>key.pem</code>, which contains your private key. Copy in the full private key, including the <code>BEGIN</code> and <code>END</code> delimiter lines, under <code>serviceProviderKey</code>.</br>
+    For RSA keys, you only need to configure the private key.
+    </td>
+  </tr>
+  <tr>
+    <td><pre><code>
     scim:
       users:
       - name: admin

--- a/common/vsphere-vcloud-cf-stub.html.md.erb
+++ b/common/vsphere-vcloud-cf-stub.html.md.erb
@@ -204,7 +204,25 @@ properties:
     <td>Generate a PEM-encoded RSA key pair, and replace <code>JWT_SIGNING_KEY</code> with the private key, and <code>JWT_VERIFICATION_KEY</code> with the corresponding public key. You can generate a key pair by running the command <code>openssl rsa -in jwt-key.pem -pubout > key.pub</code>. This command creates <code>jwt-key.pem.pub</code>, which contains your public key, and <code>jwt-key.pem</code>, which contains your private key.<br/>
     Copy in the full keys, including the <code>BEGIN</code> and <code>END</code> delimiter lines.
     </td>
-
+  </tr>
+  <tr>
+    <td><pre><code>
+    login:
+      saml:
+        serviceProviderKey:  |
+          -----BEGIN RSA PRIVATE KEY-----
+          MIICabcdefabcdefabcdefabcdef
+          MIICabcdefabcdefabcdefabcdef
+          MIICabcdefabcdefabcdefabcdef
+          MIICabcdefabcdefabcdefabcdef
+          MIICabcdefabcdefabcdefabcdef
+          MIICabcdefabcdefabcdefabcdef
+          MIICabcdefabcdefabcdefabcdef==
+          -----END RSA PRIVATE KEY-----
+    </code></pre></td>
+    <td>Generate a PEM-encoded RSA key pair. You can generate a key pair by running the command <code>openssl req -x509 -nodes -newkey rsa:2048 -days 365 -keyout key.pem -out cert.pem</code>. This command creates <code>cert.pem</code>, which contains your public key, and <code>key.pem</code>, which contains your private key. Copy in the full private key, including the <code>BEGIN</code> and <code>END</code> delimiter lines, under <code>serviceProviderKey</code>.</br>
+    For RSA keys, you only need to configure the private key.
+    </td>
   </tr>
   <tr>
     <td><pre><code>

--- a/openstack/cf-stub.html.md.erb
+++ b/openstack/cf-stub.html.md.erb
@@ -234,6 +234,25 @@ properties:
   </tr>
   <tr>
     <td><pre><code>
+    login:
+      saml:
+        serviceProviderKey:  |
+          -----BEGIN RSA PRIVATE KEY-----
+          MIICabcdefabcdefabcdefabcdef
+          MIICabcdefabcdefabcdefabcdef
+          MIICabcdefabcdefabcdefabcdef
+          MIICabcdefabcdefabcdefabcdef
+          MIICabcdefabcdefabcdefabcdef
+          MIICabcdefabcdefabcdefabcdef
+          MIICabcdefabcdefabcdefabcdef==
+          -----END RSA PRIVATE KEY-----
+    </code></pre></td>
+    <td>Generate a PEM-encoded RSA key pair. You can generate a key pair by running the command <code>openssl req -x509 -nodes -newkey rsa:2048 -days 365 -keyout key.pem -out cert.pem</code>. This command creates <code>cert.pem</code>, which contains your public key, and <code>key.pem</code>, which contains your private key. Copy in the full private key, including the <code>BEGIN</code> and <code>END</code> delimiter lines, under <code>serviceProviderKey</code>.</br>
+    For RSA keys, you only need to configure the private key.
+    </td>
+  </tr>
+  <tr>
+    <td><pre><code>
     scim:
       users:
       - name: admin


### PR DESCRIPTION
**NB: Do not merge this until after CF 252 is cut.**

The fixture was not updated during CF 251, even though it should have been. As such, the fixture will be available in the next final release, at which point this doc change would make sense.