### PR TITLE
Added serviceProviderCertificate to login.saml section in the stud ex…

### DIFF
--- a/openstack/cf-stub.html.md.erb
+++ b/openstack/cf-stub.html.md.erb
@@ -243,6 +243,7 @@ properties:
     login:
       protocol: http
       saml:
+        serviceProviderCertificate: SERVICE_PROVIDER_CERTIFICATE
         serviceProviderKey: SERVICE_PROVIDER_PRIVATE_KEY
     </code></pre></td>
     <td>Generate a PEM-encoded RSA key pair. You can generate a key pair by running the command 


### PR DESCRIPTION
…ample to avoid deployment errors

The deployment fails when you miss the login.saml.serviceProviderCertificate line with error of not having the certificate.

