### PR TITLE
Added info about restricted chars in bulk_api_password

### DIFF
--- a/aws/cf-stub.html.md.erb
+++ b/aws/cf-stub.html.md.erb
@@ -173,7 +173,7 @@ properties:
     <td>
       The Cloud Controller API endpoint requires basic authentication. Replace <code>STAGING_UPLOAD_USER</code> and <code>STAGING_UPLOAD_PASSWORD</code> with a username and password of your choosing.
       <br /><br />
-      Replace <code>BULK_API_PASSWORD</code> with a password of your choosing. Health Manager uses this password to access the Cloud Controller bulk API.
+      Replace <code>BULK_API_PASSWORD</code> with a password of your choosing. The password cannot contain chars that are not allowed for basic auth or those chars should be encoded. Health Manager uses this password to access the Cloud Controller bulk API.
       <br /><br />
       Replace <code>CCDB_ENCRYPTION_KEY</code> with a secure key that you generate to encrypt sensitive values in the Cloud Controller database.
       You can use any random string. For example, run the following command from a command line to generate a 32-character random string: <code>LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 32 ; echo</code>


### PR DESCRIPTION
According to https://github.com/cloudfoundry/cf-release/issues/992#issuecomment-228824498 some chars in BULK_API_PASSWORD are restricted. 
This PR can save some time for resolving deployment errors (I encountered this problem today)