### PR TITLE
Unify docs for generating JWT signing keys

### DIFF
--- a/aws/cf-stub.html.md.erb
+++ b/aws/cf-stub.html.md.erb
@@ -423,7 +423,7 @@ properties:
       signing_key: JWT_SIGNING_KEY
     </code></pre></td>
     <td>Generate a PEM-encoded RSA key pair, and replace <code>JWT_SIGNING_KEY</code> with the private key, and <code>JWT_VERIFICATION_KEY</code>
-        with the corresponding public key. Generate a key pair by running the command <code>openssl rsa -in jwt-key.pem -pubout > key.pub</code>.
+        with the corresponding public key. Generate a key pair by running the command <code>openssl genrsa -out jwt-key.pem 2048 && openssl rsa -pubout -in jwt-key.pem -out jwt-key.pem.pub</code>.
         This command creates <code>jwt-key.pem.pub</code>, which contains your public key, and <code>jwt-key.pem</code>, which contains your private key.<br/>
     Copy in the full keys, including the <code>BEGIN</code> and <code>END</code> delimiter lines.
     </td>

--- a/azure/cf-stub.html.md.erb
+++ b/azure/cf-stub.html.md.erb
@@ -271,8 +271,10 @@ properties:
       verification_key: JWT_VERIFICATION_KEY
       signing_key: JWT_SIGNING_KEY
     </code></pre></td>
-    <td>Generate a PEM-encoded RSA key pair, and replace <code>JWT_SIGNING_KEY</code> with the private key, and <code>JWT_VERIFICATION_KEY</code> with the corresponding public key. You can generate a key pair with the following command: <code>openssl genrsa -out jwt_signing_key 2048 && openssl rsa -pubout -in jwt_signing_key -out jwt_verification_key</code>
-    Copy and paste the full keys with correct indentation, including the <code>BEGIN</code> and <code>END</code> delimiter lines.
+    <td>Generate a PEM-encoded RSA key pair, and replace <code>JWT_SIGNING_KEY</code> with the private key, and <code>JWT_VERIFICATION_KEY</code>
+        with the corresponding public key. Generate a key pair by running the command <code>openssl genrsa -out jwt-key.pem 2048 && openssl rsa -pubout -in jwt-key.pem -out jwt-key.pem.pub</code>.
+        This command creates <code>jwt-key.pem.pub</code>, which contains your public key, and <code>jwt-key.pem</code>, which contains your private key.<br/>
+    Copy in the full keys, including the <code>BEGIN</code> and <code>END</code> delimiter lines.
     </td>
   </tr>
   <tr>

--- a/common/vsphere-vcloud-cf-stub.html.md.erb
+++ b/common/vsphere-vcloud-cf-stub.html.md.erb
@@ -336,8 +336,8 @@ Run <code>generate-loggregator-certs CA_CERT CA_KEY</code> to generate the certi
       verification_key: JWT_VERIFICATION_KEY
       signing_key: JWT_SIGNING_KEY
     </code></pre></td>
-    <td>Generate a PEM-encoded RSA key pair, and replace <code>JWT_SIGNING_KEY</code> with the private key, and <code>JWT_VERIFICATION_KEY</code> 
-        with the corresponding public key. Generate a key pair by running the command <code>openssl rsa -in jwt-key.pem -pubout > key.pub</code>. 
+    <td>Generate a PEM-encoded RSA key pair, and replace <code>JWT_SIGNING_KEY</code> with the private key, and <code>JWT_VERIFICATION_KEY</code>
+        with the corresponding public key. Generate a key pair by running the command <code>openssl genrsa -out jwt-key.pem 2048 && openssl rsa -pubout -in jwt-key.pem -out jwt-key.pem.pub</code>.
         This command creates <code>jwt-key.pem.pub</code>, which contains your public key, and <code>jwt-key.pem</code>, which contains your private key.<br/>
     Copy in the full keys, including the <code>BEGIN</code> and <code>END</code> delimiter lines.
     </td>

--- a/openstack/cf-stub.html.md.erb
+++ b/openstack/cf-stub.html.md.erb
@@ -357,13 +357,9 @@ Run <code>generate-loggregator-certs CA_CERT CA_KEY</code> to generate the certi
       verification_key: JWT_VERIFICATION_KEY
       signing_key: JWT_SIGNING_KEY
     </code></pre></td>
-    <td>Generate a PEM-encoded RSA key pair, and replace <code>JWT_SIGNING_KEY</code> with the private key, and <code>JWT_VERIFICATION_KEY</code> with the corresponding public key. You can generate a key pair by running the following command:
-
-    <p><code>openssl genrsa -des3 -out jwt-key.pem 2048 && openssl rsa -in jwt-key.pem -pubout > key.pub</code></p>
-
-    This command creates the <code>jwt-key.pem.pub</code> file, which contains your public key, and the <code>jwt-key.pem</code> file, which contains your private key. If you were prompted for a passphrase, you must strip it from the private key with the following command: 
-
-    <p><code>openssl rsa -in jwt-key.pem -out jwt-key.pem</code></p>
+    <td>Generate a PEM-encoded RSA key pair, and replace <code>JWT_SIGNING_KEY</code> with the private key, and <code>JWT_VERIFICATION_KEY</code>
+        with the corresponding public key. Generate a key pair by running the command <code>openssl genrsa -out jwt-key.pem 2048 && openssl rsa -pubout -in jwt-key.pem -out jwt-key.pem.pub</code>.
+        This command creates <code>jwt-key.pem.pub</code>, which contains your public key, and <code>jwt-key.pem</code>, which contains your private key.<br/>
     Copy in the full keys, including the <code>BEGIN</code> and <code>END</code> delimiter lines.
     </td>
   </tr>


### PR DESCRIPTION
There was some inconsistency between the IaaS-specific documentation here. More importantly, only some of the docs included the critical `openssl genrsa` command for generating a private key.

See also: https://github.com/cloudfoundry/cf-release/issues/1222