### PR TITLE
Add serviceProviderCertificate and serviceProviderKey to vsphere

### DIFF
--- a/common/vsphere-vcloud-cf-stub.html.md.erb
+++ b/common/vsphere-vcloud-cf-stub.html.md.erb
@@ -270,6 +270,7 @@ Run <code>generate-loggregator-certs CA_CERT CA_KEY</code> to generate the certi
     login:
       protocol: http
       saml:
+        serviceProviderCertificate: SERVICE_PROVIDER_CERTIFICATE
         serviceProviderKey: SERVICE_PROVIDER_PRIVATE_KEY
     </code></pre></td>
     <td>Generate a PEM-encoded RSA key pair. You can generate a key pair by running the 


### PR DESCRIPTION
serviceProviderCertificate and serviceProviderKey are required for newer releases so I'm updating the vsphere doc to more closely match the openstack doc.