### PR TITLE
Add note about job vs instance group names in dns_prereq doc

### DIFF
--- a/common/dns_prereqs.html.md.erb
+++ b/common/dns_prereqs.html.md.erb
@@ -50,6 +50,15 @@ Your must create several wildcard DNS records to point to your load balancer(s) 
 
 Your exact configuration will vary significantly depending on your IaaS and your load balancing configuration. Below are two example topologies: the [first](#aws) is an Amazon Web Services (AWS) deployment using Elastic Load Balancer (ELBs), and the [second](#haproxy) uses HAProxy for load balancing.
 
+The diagrams below show which particular jobs will have traffic routed to them by load balancers.
+It's worth noting that the instance groups
+-- the names that `bosh instances` shows --
+may have different names.
+For example,
+in a default [cf-deployment](https://github.com/cloudfoundry/cf-deployment),
+the `ssh_proxy` job will be deployed to an instance group called `scheduler`.
+Your load balancers will need to route traffic to that VM.
+
 ###<a id='aws'></a> AWS
 
 This topology has DNS configured to point five domains to four ELBs:


### PR DESCRIPTION
We got some feedback (https://github.com/cloudfoundry/cf-deployment/issues/58#issuecomment-329468063) that it would be good to call out which instance groups (in addition to jobs) are involved in load balancing. I took a shot at it here.