### PR TITLE
Change tar to unzip as terraform is zip arcived

### DIFF
--- a/cf-deployment/gcp.html.md.erb
+++ b/cf-deployment/gcp.html.md.erb
@@ -36,7 +36,7 @@ Perform the following steps to download the required dependencies for bosh-bootl
 
 1. Download [Terraform](https://www.terraform.io/downloads.html) v0.9.1 or later. Unzip the file and move it to somewhere in your PATH:
     <pre class="terminal">
-    $ tar xvf ~/Downloads/terraform*
+    $ unzip ~/Downloads/terraform*
     $ sudo mv ~/Downloads/terraform /usr/local/bin/terraform
     </pre>
 


### PR DESCRIPTION
As terraform is zip archive, I think unzip should be used istead of tar, as it described above in docs