### PR TITLE
Update documentation for using AWS IAM instance profiles

### DIFF
--- a/common/cc-blobstore-config.html.md.erb
+++ b/common/cc-blobstore-config.html.md.erb
@@ -160,7 +160,63 @@ AWS S3 offers Server-Side Encryption at rest. For more information, see <a href=
 
 To configure Fog blobstores to use <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html">AWS IAM Instance Profiles</a>, perform the steps below:
 
-1. Insert the following configuration into your manifest under `properties.cc`:
+1. Configure an additional <code>cloud-controller</code> IAM role with the following policy to give access to the S3 buckets you plan to use:
+
+    ```
+    {
+      "Version": "2012-10-17",
+      "Statement": [{
+        "Effect": "Allow",
+        "Action": [ "s3:*" ],
+        "Resource": [
+          "arn:aws:s3:::YOUR-AWS-BUILDPACK-BUCKET",
+          "arn:aws:s3:::YOUR-AWS-BUILDPACK-BUCKET/*",
+          "arn:aws:s3:::YOUR-AWS-DROPLET-BUCKET",
+          "arn:aws:s3:::YOUR-AWS-DROPLET-BUCKET/*",
+          "arn:aws:s3:::YOUR-AWS-PACKAGE-BUCKET",
+          "arn:aws:s3:::YOUR-AWS-PACKAGE-BUCKET/*",
+          "arn:aws:s3:::YOUR-AWS-RESOURCE-BUCKET",
+          "arn:aws:s3:::YOUR-AWS-RESOURCE-BUCKET/*",
+        ]
+      }]
+    }
+    ```
+
+    Replace `YOUR-AWS-BUILDPACK-BUCKET`, `YOUR-AWS-DROPLET-BUCKET`, `YOUR-AWS-PACKAGE-BUCKET`, and `YOUR-AWS-RESOURCE-BUCKET` with the names of your AWS buckets. Do not use periods (`.`) in your AWS bucket names.
+
+    If you use the AWS console, an IAM Role is automatically assigned to an IAM Instance Profile with the same name, <code>cloud-controller</code>. If you do not use the AWS console, you must create an IAM Instance Profile with a single assigned IAM Role (instructions [here](https://docs.aws.amazon.com/codedeploy/latest/userguide/getting-started-create-iam-instance-profile.html)).
+
+1. In your [bosh cloud config](https://bosh.io/docs/cloud-config/), create a [vm_extension](https://bosh.io/docs/cloud-config/#vm-extensions) to add the IAM Instance Profile you created to vms using the extension.
+
+    ```
+    vm_extensions:
+    - cloud_properties:
+        iam_instance_profile: cloud-controller
+      name: cloud-controller-iam
+    ```
+
+1. In your Cloud Foundry deployment manifest use the `cloud-controller-iam` vm_extension you created for the instance groups containing cloud_controller, cloud_controller_worker, and cloud_controller_clock (for example in cf_deployment: api, cc-clock, and scheduler instance groups).
+
+    ```
+    instance_groups:
+    ...
+    - name: api
+      ...
+      vm_extensions:
+      - cloud-controller-iam
+    ...
+    - name: cc-worker
+      ...
+      vm_extensions:
+      - cloud-controller-iam
+    ...
+    - name: scheduler
+      ...
+      vm_extensions:
+      - cloud-controller-iam
+    ```
+
+1. Insert the following configuration into your deployment manifest under `properties.cc`:
 
     ```
     cc:
@@ -184,47 +240,10 @@ To configure Fog blobstores to use <a href="http://docs.aws.amazon.com/IAM/lates
         resource_directory_key: YOUR-AWS-RESOURCE-BUCKET
         fog_connection: *fog_connection
     ```
-1. Replace `YOUR-AWS-BUILDPACK-BUCKET`, `YOUR-AWS-DROPLET-BUCKET`, `YOUR-AWS-PACKAGE-BUCKET`, and `YOUR-AWS-RESOURCE-BUCKET` with the names of your AWS buckets. Do not use periods (`.`) in your AWS bucket names. 
 
-1. To provide further configuration, create a <code>fog_connection</code> hash to pass through to the Fog gem.
+    Replace `YOUR-AWS-BUILDPACK-BUCKET`, `YOUR-AWS-DROPLET-BUCKET`, `YOUR-AWS-PACKAGE-BUCKET`, and `YOUR-AWS-RESOURCE-BUCKET` with the names of your AWS buckets. Do not use periods (`.`) in your AWS bucket names.
 
-1. Complete the steps documented in the <a href="http://bosh.io/docs/aws-iam-instance-profiles.html#director-with-s3-blobstore">AWS CPI and Director configured with an S3 blobstore instructions</a> section of the BOSH documentation.
-
-1. In the AWS console, configure an additional <code>cloud-controller</code> IAM role that gives access to both the BOSH S3 buckets and the Cloud Controller S3 buckets specified in your manifest:
-
-    ```
-    {
-      "Version": "2012-10-17",
-      "Statement": [{
-        "Effect": "Allow",
-        "Action": [ "s3:*" ],
-        "Resource": [
-          "arn:aws:s3:::YOUR-AWS-BUILDPACK-BUCKET",
-          "arn:aws:s3:::YOUR-AWS-BUILDPACK-BUCKET/*",
-          "arn:aws:s3:::YOUR-AWS-DROPLET-BUCKET",
-          "arn:aws:s3:::YOUR-AWS-DROPLET-BUCKET/*",
-          "arn:aws:s3:::YOUR-AWS-PACKAGE-BUCKET",
-          "arn:aws:s3:::YOUR-AWS-PACKAGE-BUCKET/*",
-          "arn:aws:s3:::YOUR-AWS-RESOURCE-BUCKET",
-          "arn:aws:s3:::YOUR-AWS-RESOURCE-BUCKET/*",
-        ]
-      }]
-    }
-    ```
-If you use the AWS console, an IAM Role is automatically assigned to an IAM Instance Profile with the same name, <code>cloud-controller</code>. If you do not use the AWS console, you must create an IAM Instance Profile with a single assigned IAM Role.
-
-1. In your Cloud Foundry deployment manifest, configure a resource pool to use the <code>cloud-controller</code> IAM Instance Profile:
-
-    ```
-    resource_pools:
-    - name: cloud-controller-resource-pool
-      network: default
-      stemcell: { ... }
-      cloud_properties:
-        instance_type: c3.large
-        iam_instance_profile: cloud-controller
-    ```
-1. Assign all Cloud Controller jobs, identified by <code>api\_z\*</code>, and Cloud Controller Worker jobs, identified by <code>api\_worker\_z\*</code>, to the <code>cloud-controller-resource-pool</code>.
+1. (Optional) Provide other configuration with the `fog_connection` hash, which is passed through to the Fog gem.
 
 ##<a id="fog-gcs"></a>Fog with Google Cloud Storage
 

--- a/common/cc-blobstore-config.html.md.erb
+++ b/common/cc-blobstore-config.html.md.erb
@@ -28,7 +28,7 @@ This document describes the following common blobstore configurations:
 
 ##<a id="fog-aws-creds"></a> Fog with AWS Credentials
 
-To use Fog blobstores with AWS credentials, perform the steps below:
+To use Fog blobstores with AWS credentials, do the following:
 
 1. Insert the following configuration into your manifest under `properties.cc`:
 
@@ -59,7 +59,7 @@ To use Fog blobstores with AWS credentials, perform the steps below:
 
 1. Replace `YOUR-AWS-BUILDPACK-BUCKET`, `YOUR-AWS-DROPLET-BUCKET`, `YOUR-AWS-PACKAGE-BUCKET`, and `YOUR-AWS-RESOURCE-BUCKET` with the names of your AWS buckets. Do not use periods (`.`) in your AWS bucket names. In the AWS console, you must assign your credentials an IAM policy that allows all S3 actions on all of these buckets. 
 
-1. (Optional) Provide additional configuration through the <code>fog_connection</code> hash, which is passed through to the Fog gem.
+1. (Optional) Provide additional configuration through the `fog_connection` hash, which is passed through to the Fog gem.
 
 ##<a id="fog-aws-sse"></a> Fog with AWS Server-Side Encryption
 
@@ -102,7 +102,7 @@ AWS S3 offers Server-Side Encryption at rest. For more information, see <a href=
 
 1. Replace `YOUR-AWS-BUILDPACK-BUCKET`, `YOUR-AWS-DROPLET-BUCKET`, `YOUR-AWS-PACKAGE-BUCKET`, and `YOUR-AWS-RESOURCE-BUCKET` with the names of your AWS buckets. Do not use periods (`.`) in your AWS bucket names. In the AWS console, you must assign your credentials an IAM policy that allows all S3 actions on all of these buckets. 
 
-1. You can provide further configuration through the <code>fog_connection</code> hash, which is passed through to the Fog gem.
+1. You can provide further configuration through the `fog_connection` hash, which is passed through to the Fog gem.
 
 1. `fog_aws_storage_options` takes a hash with the key `encryption`. Operators can set its value to a type of encryption algorithm. In the configuration information above, `encryption` is set to `AES256` to enable AWS SSE-S3 encryption. 
 
@@ -148,7 +148,7 @@ AWS S3 offers Server-Side Encryption at rest. For more information, see <a href=
 
 1. Replace `YOUR-AWS-BUILDPACK-BUCKET`, `YOUR-AWS-DROPLET-BUCKET`, `YOUR-AWS-PACKAGE-BUCKET`, and `YOUR-AWS-RESOURCE-BUCKET` with the names of your AWS buckets.  Do not use periods (`.`) in your AWS bucket names. In the AWS console, you must assign your credentials an IAM policy that allows all S3 actions on all of these buckets. 
 
-1. You can provide further configuration through the <code>fog_connection</code> hash, which is passed through to the Fog gem.
+1. You can provide further configuration through the `fog_connection` hash, which is passed through to the Fog gem.
 
 1. Replace `YOUR-AWS-KMS-KEY-ID` with your KMS Key ID. 
 
@@ -158,7 +158,7 @@ AWS S3 offers Server-Side Encryption at rest. For more information, see <a href=
 
 ##<a id="fog-aws-iam"></a> Fog with AWS IAM Instance Profiles
 
-To configure Fog blobstores to use <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html">AWS IAM Instance Profiles</a>, perform the steps below:
+To configure Fog blobstores to use <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html">AWS IAM Instance Profiles</a>, do the following:
 
 1. Configure an additional <code>cloud-controller</code> IAM role with the following policy to give access to the S3 buckets you plan to use:
 
@@ -184,9 +184,9 @@ To configure Fog blobstores to use <a href="http://docs.aws.amazon.com/IAM/lates
 
     Replace `YOUR-AWS-BUILDPACK-BUCKET`, `YOUR-AWS-DROPLET-BUCKET`, `YOUR-AWS-PACKAGE-BUCKET`, and `YOUR-AWS-RESOURCE-BUCKET` with the names of your AWS buckets. Do not use periods (`.`) in your AWS bucket names.
 
-    If you use the AWS console, an IAM Role is automatically assigned to an IAM Instance Profile with the same name, <code>cloud-controller</code>. If you do not use the AWS console, you must create an IAM Instance Profile with a single assigned IAM Role (instructions [here](https://docs.aws.amazon.com/codedeploy/latest/userguide/getting-started-create-iam-instance-profile.html)).
+    If you use the AWS console, an IAM Role is automatically assigned to an IAM Instance Profile with the same name, `cloud-controller`. If you do not use the AWS console, you must create an IAM Instance Profile with a single assigned IAM Role. For more information, see [Step 4: Create an IAM Instance Profile for Your Amazon EC2 Instances](https://docs.aws.amazon.com/codedeploy/latest/userguide/getting-started-create-iam-instance-profile.html) in the AWS documentation.
 
-1. In your [bosh cloud config](https://bosh.io/docs/cloud-config/), create a [vm_extension](https://bosh.io/docs/cloud-config/#vm-extensions) to add the IAM Instance Profile you created to vms using the extension.
+1. In your [BOSH cloud config](https://bosh.io/docs/cloud-config/), create a [VM extension](https://bosh.io/docs/cloud-config/#vm-extensions) to add the IAM Instance Profile you created to VMs using the extension.
 
     ```
     vm_extensions:
@@ -195,7 +195,7 @@ To configure Fog blobstores to use <a href="http://docs.aws.amazon.com/IAM/lates
       name: cloud-controller-iam
     ```
 
-1. In your Cloud Foundry deployment manifest use the `cloud-controller-iam` vm_extension you created for the instance groups containing cloud_controller, cloud_controller_worker, and cloud_controller_clock (for example in cf_deployment: api, cc-clock, and scheduler instance groups).
+1. In your Cloud Foundry deployment manifest, use the `cloud-controller-iam` VM extension you created for the instance groups containing `cloud_controller`, `cloud_controller_worker`, and `cloud_controller_clock`, as in the example below:
 
     ```
     instance_groups:
@@ -247,7 +247,7 @@ To configure Fog blobstores to use <a href="http://docs.aws.amazon.com/IAM/lates
 
 ##<a id="fog-gcs"></a>Fog with Google Cloud Storage
 
-To configure your blobstores to use Google Cloud Storage Interoperability credentials, perform the steps below:
+To configure your blobstores to use Google Cloud Storage Interoperability credentials, do the following:
 
 1. Insert the following configuration into your manifest under `properties.cc`:
 
@@ -283,7 +283,7 @@ To configure your blobstores to use Google Cloud Storage Interoperability creden
 
 ##<a id="fog-gcs-service-account"></a>Fog with Google Cloud Storage Service Accounts
 
-To configure your blobstore to use Google Cloud Storage with a service account, perform the steps below:
+To configure your blobstore to use Google Cloud Storage with a service account, do the following:
 
 1. Create a custom Cloud IAM role with the following permissions:
 
@@ -356,7 +356,7 @@ You need this key to configure your blobstore.
 
 ##<a id="fog-azure"></a>Fog with Azure Storage
 
-To configure your blobstores to use Azure Storage credentials, perform the steps below:
+To configure your blobstores to use Azure Storage credentials, do the following:
 
 1. Insert the following configuration into your manifest under `properties.cc`:
 
@@ -388,11 +388,11 @@ To configure your blobstores to use Azure Storage credentials, perform the steps
 
 1. Replace `YOUR-AZURE-BUILDPACK-CONTAINER`, `YOUR-AZURE-DROPLET-CONTAINER`, `YOUR-AZURE-PACKAGE-CONTAINER`, and `YOUR-AZURE-RESOURCE-CONTAINER` with the names of your Cloud Storage containers. 
 
-1. You can provide further configuration through the <code>fog_connection</code> hash, which is passed through to the Fog gem.
+1. You can provide further configuration through the `fog_connection` hash, which is passed through to the Fog gem.
 
 ##<a id="fog-local-nfs"></a>Fog with NFS
 
-To configure your blobstores to use an NFS-mounted directory, perform the steps below:
+To configure your blobstores to use an NFS-mounted directory, do the following:
 
 1. Insert the following configuration into your manifest under `properties.cc`:
 
@@ -486,7 +486,7 @@ To configure your blobstores to use the WebDAV protocol, perform the steps below
         webdav_config: *webdav_config
     ```
 
-1. Configure your WebDAV blobstores by performing the following steps:
+1. Configure your WebDAV blobstores by doing the following:
       * Replace <code>WEBDAV-BASIC-AUTH-USER</code> and <code>WEBDAV-BASIC-AUTH-PASSWORD</code> with Basic AUTH credentials that Cloud Controller can use to communicate with your WebDAV installation.
       * Replace <code>WEBDAV-SECRET</code> with a secret phrase used to sign URLs.
       * Replace <code>WEBDAV-CERT</code>, <code>WEBDAV-PRIVATE-KEY</code>, and <code>WEBDAV-CA-CERT-BUNDLE</code> with proper TLS configuration that are used for the internal blobstore.


### PR DESCRIPTION
Resource pools are an old bosh concept, and have been replaced by
vm_types and vm_extensions in the cloud_config

Tracker story: https://www.pivotaltracker.com/story/show/155385063

Signed-off-by: Eric Promislow <eric.promislow@suse.com>