### PR TITLE
Add vSphere and OpenStack to the supported IaaS environments for bosh-bootloader

### DIFF
--- a/cf-deployment/index.html.md.erb
+++ b/cf-deployment/index.html.md.erb
@@ -28,9 +28,11 @@ Select the topic specific to your IaaS:
 * [Deploying BOSH on AWS](../common/aws.html)
 * [Deploying BOSH on GCP](./gcp.html)
 * [Deploying BOSH on Azure](./azure.html)
+* [Deploying BOSH on vSphere](https://github.com/cloudfoundry/bosh-bootloader/blob/master/docs/getting-started-vsphere.md)
+* [Deploying BOSH on OpenStack](https://github.com/cloudfoundry/bosh-bootloader/blob/master/docs/getting-started-openstack.md)
 
 <p class="note"><strong>Note</strong>: The topics for preparing your 
-environment use the <code>bosh-bootloader</code> tool. <code>bosh-bootloader</code> is currently compatible with GCP, AWS, and Microsoft Azure.</p>
+environment use the <code>bosh-bootloader</code> tool. <code>bosh-bootloader</code> is currently compatible with GCP, AWS, Microsoft Azure, VMware vSphere and OpenStack.</p>
 
 ##<a id='deploy'></a> Deploy Cloud Foundry
 


### PR DESCRIPTION
The list of supported bosh-bootloader environments in this document differed from those listed in the bosh-bootloader source [1] itself, which claims that bosh-bootloader also supports vSphere and OpenStack.

[1]: https://github.com/cloudfoundry/bosh-bootloader