### PR TITLE
Make manual DNS step after bbl just an example

### DIFF
--- a/common/aws.html.md.erb
+++ b/common/aws.html.md.erb
@@ -142,7 +142,7 @@ Replace the placeholders as follows:
 
 The `bbl up` command takes five to eight minutes to complete.
 
-After `bbl` deploys the BOSH Director, you must point the parent domain at the BOSH Director's name servers. Do the following:
+After `bbl` deploys the BOSH Director, you must point `YOUR-SYSTEM-DOMAIN` at the BOSH Director's name servers. For example, if you are using AWS Route53 to manage `YOUR-SYSTEM-DOMAIN` then do the following:
 
 1. Run `--lb-domain YOUR-ENV-NAME.YOUR-SYSTEM-DOMAIN`.
 
@@ -150,7 +150,7 @@ After `bbl` deploys the BOSH Director, you must point the parent domain at the B
 
 1. Log in to the AWS Route 53 dashboard and go to **Registered Domains**.
 
-1. Choose the name of your parent domain.
+1. Choose `YOUR-SYSTEM-DOMAIN`.
 
 1. Click **Add/Edit Name Servers**.
 


### PR DESCRIPTION
The manual DNS step involves editing the parent DNS zone, which is not necessarily on the same IAAS. For example, you could `bbl up` on AWS but manage your DNS on GCP. In that case, you would update the parent DNS zone on GCP.